### PR TITLE
chore: use full GitHub module path so go install works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module diffyml
+module github.com/szhekpisov/diffyml
 
 go 1.25.0
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"diffyml/pkg/diffyml"
+	"github.com/szhekpisov/diffyml/pkg/diffyml"
 )
 
 // Version information - can be overridden at build time using ldflags

--- a/pkg/diffyml/compare_test.go
+++ b/pkg/diffyml/compare_test.go
@@ -23,7 +23,7 @@ package diffyml_test
 import (
 	"testing"
 
-	"diffyml/pkg/diffyml"
+	"github.com/szhekpisov/diffyml/pkg/diffyml"
 )
 
 func TestCompare(t *testing.T) {

--- a/pkg/diffyml/helpers_test.go
+++ b/pkg/diffyml/helpers_test.go
@@ -1,7 +1,7 @@
 package diffyml_test
 
 import (
-	"diffyml/pkg/diffyml"
+	"github.com/szhekpisov/diffyml/pkg/diffyml"
 )
 
 // yml converts a YAML string to bytes for testing.

--- a/test/property/repository_structure_test.go
+++ b/test/property/repository_structure_test.go
@@ -441,7 +441,7 @@ func TestProperty19_ModuleNameConsistency_WithImportPath(t *testing.T) {
 			}
 
 			// For simple module names, imports should use the module name as prefix
-			// Example: module diffyml, import "diffyml/pkg/diffyml"
+			// Example: module github.com/szhekpisov/diffyml, import "github.com/szhekpisov/diffyml/pkg/diffyml"
 			expectedImportPrefix := moduleName + "/"
 			hasConsistentImport := strings.Contains(mainText, `"`+expectedImportPrefix) ||
 				strings.Contains(mainText, `'`+expectedImportPrefix)

--- a/test/property/test_system_test.go
+++ b/test/property/test_system_test.go
@@ -64,7 +64,7 @@ func TestProperty6_TestExecutionSuccess_PackageDiscovery(t *testing.T) {
 	outputStr := string(output)
 
 	// Verify the package was tested
-	hasPackageOutput := strings.Contains(outputStr, "diffyml/pkg/diffyml") ||
+	hasPackageOutput := strings.Contains(outputStr, "github.com/szhekpisov/diffyml/pkg/diffyml") ||
 		strings.Contains(outputStr, "ok")
 
 	if !hasPackageOutput {


### PR DESCRIPTION
## Summary
- Update `go.mod` module path from `diffyml` to `github.com/szhekpisov/diffyml` so `go install github.com/szhekpisov/diffyml@latest` works
- Update all internal imports and test assertions to match the new module path

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` all tests pass
- [x] `go install .` installs successfully