### PR TITLE
doc: add GOPATH/bin PATH hint to Go Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Structural diff for YAML files. Understands YAML semantics and detects Kubernete
 go install github.com/szhekpisov/diffyml@latest
 ```
 
+Make sure `$GOPATH/bin` is in your `PATH`:
+
+```bash
+export PATH="$(go env GOPATH)/bin:$PATH"
+```
+
 ### Homebrew
 
 Coming soon.


### PR DESCRIPTION
## Summary
- Add a note after `go install` reminding users to ensure `$GOPATH/bin` is in their `PATH`

## Test plan
- [x] Verify README renders correctly on GitHub