### PR TITLE
feat: add OpenSSF Scorecard workflow and badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: Scorecard analysis
+on:
+  push:
+    branches:
+    - main
+  schedule:
+    - cron: '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4.32.0
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Structural diff for YAML files. Understands YAML semantics and detects Kubernete
 [![Go Report Card](https://goreportcard.com/badge/github.com/szhekpisov/diffyml)](https://goreportcard.com/report/github.com/szhekpisov/diffyml)
 [![Security & Static Analysis](https://github.com/szhekpisov/diffyml/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/szhekpisov/diffyml/actions/workflows/security.yml)
 [![Benchmark](https://github.com/szhekpisov/diffyml/actions/workflows/benchmark.yml/badge.svg?branch=main)](https://github.com/szhekpisov/diffyml/actions/workflows/benchmark.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/szhekpisov/diffyml/badge)](https://scorecard.dev/viewer/?uri=github.com/szhekpisov/diffyml)
 
 ## Features
 


### PR DESCRIPTION
## What

Add OpenSSF Scorecard GitHub Action workflow and badge to README.

## Why

The OpenSSF Scorecard badge is a recognized supply-chain security trust signal. It requires a workflow to generate and publish the score for non-critical repos.

## How

- New `.github/workflows/scorecard.yml` based on the [official reference](https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml)
  - Triggers on push to main + weekly (Saturday)
  - Publishes results to scorecard.dev (`publish_results: true`)
  - Uploads SARIF to GitHub code scanning
  - All action references pinned by SHA (Dependabot-compatible)
- Added OpenSSF Scorecard badge to README after existing badges

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `doc:`, `chore:`)
- [x] No new dependencies
- [ ] Badge will render after first workflow run on main