### PR TITLE
feat: rename --color values from on/off to GNU-standard always/never

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ diffyml -s before.yaml after.yaml || echo "Config drift detected"
 | Flag | Description |
 |------|-------------|
 | `-o, --output <style>` | Output style: `detailed`, `compact`, `brief`, `github`, `gitlab`, `gitea` (default `detailed`) |
-| `-c, --color <mode>` | Color usage: `on`, `off`, `auto` (default `auto`) |
-| `-t, --truecolor <mode>` | True color (24-bit): `on`, `off`, `auto` (default `auto`) |
+| `-c, --color <mode>` | Color usage: `always`, `never`, `auto` (default `auto`) |
+| `-t, --truecolor <mode>` | True color (24-bit): `always`, `never`, `auto` (default `auto`) |
 | `-w, --fixed-width <int>` | Fixed terminal width instead of auto-detection |
 
 **Comparison**

--- a/pkg/diffyml/cli.go
+++ b/pkg/diffyml/cli.go
@@ -23,8 +23,8 @@ type CLIConfig struct {
 
 	// Output options
 	Output    string // compact, brief, github, gitlab, gitea, detailed
-	Color     string // on, off, auto
-	TrueColor string // on, off, auto
+	Color     string // always, never, auto
+	TrueColor string // always, never, auto
 
 	// Display options
 	FixedWidth            int
@@ -88,9 +88,9 @@ func (c *CLIConfig) initFlags() {
 	c.fs.StringVar(&c.Output, "o", c.Output, "")
 	c.fs.StringVar(&c.Output, "output", c.Output, "specify the output style: compact, brief, github, gitlab, gitea, detailed")
 	c.fs.StringVar(&c.Color, "c", c.Color, "")
-	c.fs.StringVar(&c.Color, "color", c.Color, "specify color usage: on, off, or auto")
+	c.fs.StringVar(&c.Color, "color", c.Color, "specify color usage: always, never, or auto")
 	c.fs.StringVar(&c.TrueColor, "t", c.TrueColor, "")
-	c.fs.StringVar(&c.TrueColor, "truecolor", c.TrueColor, "specify true color usage: on, off, or auto")
+	c.fs.StringVar(&c.TrueColor, "truecolor", c.TrueColor, "specify true color usage: always, never, or auto")
 
 	// Display options
 	c.fs.IntVar(&c.FixedWidth, "w", c.FixedWidth, "")
@@ -222,8 +222,8 @@ func (c *CLIConfig) Usage() string {
 
 	// Output options
 	sb.WriteString("  -o, --output string                 specify output style: compact, brief, github, gitlab, gitea, detailed (default \"detailed\")\n")
-	sb.WriteString("  -c, --color string                  specify color usage: on, off, or auto (default \"auto\")\n")
-	sb.WriteString("  -t, --truecolor string              specify true color usage: on, off, or auto (default \"auto\")\n")
+	sb.WriteString("  -c, --color string                  specify color usage: always, never, or auto (default \"auto\")\n")
+	sb.WriteString("  -t, --truecolor string              specify true color usage: always, never, or auto (default \"auto\")\n")
 	sb.WriteString("  -w, --fixed-width int               disable terminal width detection and use provided fixed value (default -1)\n")
 	sb.WriteString("\n")
 
@@ -286,12 +286,12 @@ func (c *CLIConfig) Validate() error {
 
 	// Validate color mode
 	if _, err := ParseColorMode(c.Color); err != nil {
-		return fmt.Errorf("invalid color mode %q, valid modes: on, off, auto", c.Color)
+		return fmt.Errorf("invalid color mode %q, valid modes: always, never, auto", c.Color)
 	}
 
 	// Validate truecolor mode
 	if _, err := ParseColorMode(c.TrueColor); err != nil {
-		return fmt.Errorf("invalid truecolor mode %q, valid modes: on, off, auto", c.TrueColor)
+		return fmt.Errorf("invalid truecolor mode %q, valid modes: always, never, auto", c.TrueColor)
 	}
 
 	// Validate regex patterns
@@ -527,7 +527,7 @@ func Run(cfg *CLIConfig, rc *RunConfig) *ExitResult {
 	// Apply color configuration
 	colorMode, _ := ParseColorMode(cfg.Color)
 	trueColorMode, _ := ParseColorMode(cfg.TrueColor)
-	colorCfg := NewColorConfig(colorMode, trueColorMode == ColorModeOn, cfg.FixedWidth)
+	colorCfg := NewColorConfig(colorMode, trueColorMode == ColorModeAlways, cfg.FixedWidth)
 	colorCfg.DetectTerminal()
 	colorCfg.ToFormatOptions(formatOpts)
 

--- a/pkg/diffyml/cli_fixture_test.go
+++ b/pkg/diffyml/cli_fixture_test.go
@@ -84,7 +84,7 @@ func runFixture(t *testing.T, dir string) {
 	}
 
 	// Force runner invariants after ParseArgs (so params.cfg cannot override)
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.SetExitCode = true
 
 	rc := NewRunConfig()
@@ -154,7 +154,7 @@ func runDirectoryFixture(t *testing.T, dir string) {
 	}
 
 	// Force runner invariants
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.SetExitCode = true
 
 	rc := NewRunConfig()

--- a/pkg/diffyml/cli_test.go
+++ b/pkg/diffyml/cli_test.go
@@ -120,17 +120,17 @@ func TestCLIConfig_ParseArgs_SetExitCode(t *testing.T) {
 	}
 }
 
-func TestCLIConfig_ParseArgs_ColorOn(t *testing.T) {
+func TestCLIConfig_ParseArgs_ColorAlways(t *testing.T) {
 	cfg := NewCLIConfig()
-	args := []string{"-c", "on", "from.yaml", "to.yaml"}
+	args := []string{"-c", "always", "from.yaml", "to.yaml"}
 
 	err := cfg.ParseArgs(args)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if cfg.Color != "on" {
-		t.Errorf("expected Color='on', got %q", cfg.Color)
+	if cfg.Color != "always" {
+		t.Errorf("expected Color='always', got %q", cfg.Color)
 	}
 }
 
@@ -1171,7 +1171,7 @@ func TestCLI_OutputFormat_CompactWithColor(t *testing.T) {
 
 	cfg := NewCLIConfig()
 	cfg.Output = "compact"
-	cfg.Color = "on"
+	cfg.Color = "always"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -1183,9 +1183,9 @@ func TestCLI_OutputFormat_CompactWithColor(t *testing.T) {
 	Run(cfg, rc)
 
 	output := stdout.String()
-	// Should contain ANSI color codes when color is forced on
+	// Should contain ANSI color codes when color is forced always
 	if !containsSubstr(output, "\033[") {
-		t.Error("expected ANSI color codes in output with color=on")
+		t.Error("expected ANSI color codes in output with color=always")
 	}
 }
 
@@ -1195,7 +1195,7 @@ func TestCLI_OutputFormat_CompactWithoutColor(t *testing.T) {
 
 	cfg := NewCLIConfig()
 	cfg.Output = "compact"
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -1207,9 +1207,9 @@ func TestCLI_OutputFormat_CompactWithoutColor(t *testing.T) {
 	Run(cfg, rc)
 
 	output := stdout.String()
-	// Should NOT contain ANSI color codes when color is off
+	// Should NOT contain ANSI color codes when color is never
 	if containsSubstr(output, "\033[") {
-		t.Error("expected no ANSI color codes in output with color=off")
+		t.Error("expected no ANSI color codes in output with color=never")
 	}
 }
 
@@ -1485,7 +1485,7 @@ func TestRun_BothDirectories_DispatchesToDirectoryMode(t *testing.T) {
 	cfg.FromFile = fromDir
 	cfg.ToFile = toDir
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -1513,7 +1513,7 @@ func TestRun_BothDirectories_NoDiffs_Exit0(t *testing.T) {
 	cfg.FromFile = fromDir
 	cfg.ToFile = toDir
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -1544,7 +1544,7 @@ func TestRun_MixedTypes_DirAndFile_Error(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.FromFile = dir
 	cfg.ToFile = f.Name()
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -1574,7 +1574,7 @@ func TestRun_MixedTypes_FileAndDir_Error(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.FromFile = f.Name()
 	cfg.ToFile = dir
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder

--- a/pkg/diffyml/color.go
+++ b/pkg/diffyml/color.go
@@ -17,10 +17,10 @@ type ColorMode int
 const (
 	// ColorModeAuto automatically detects terminal capability.
 	ColorModeAuto ColorMode = iota
-	// ColorModeOn always enables color output.
-	ColorModeOn
-	// ColorModeOff always disables color output.
-	ColorModeOff
+	// ColorModeAlways always enables color output.
+	ColorModeAlways
+	// ColorModeNever always disables color output.
+	ColorModeNever
 )
 
 // Default terminal width when auto-detection is not possible.
@@ -29,27 +29,27 @@ const defaultTerminalWidth = 80
 // Minimum terminal width to enforce.
 const minTerminalWidth = 40
 
-// ParseColorMode parses a color mode string (on, off, auto).
+// ParseColorMode parses a color mode string (always, never, auto).
 // Empty string defaults to auto.
 func ParseColorMode(s string) (ColorMode, error) {
 	switch strings.ToLower(s) {
 	case "", "auto":
 		return ColorModeAuto, nil
-	case "on":
-		return ColorModeOn, nil
-	case "off":
-		return ColorModeOff, nil
+	case "always":
+		return ColorModeAlways, nil
+	case "never":
+		return ColorModeNever, nil
 	default:
-		return ColorModeAuto, fmt.Errorf("invalid color mode %q, valid modes: on, off, auto", s)
+		return ColorModeAuto, fmt.Errorf("invalid color mode %q, valid modes: always, never, auto", s)
 	}
 }
 
 // ResolveColorMode determines if color should be enabled based on mode and terminal state.
 func ResolveColorMode(mode ColorMode, isTerminal bool) bool {
 	switch mode {
-	case ColorModeOn:
+	case ColorModeAlways:
 		return true
-	case ColorModeOff:
+	case ColorModeNever:
 		return false
 	case ColorModeAuto:
 		return isTerminal

--- a/pkg/diffyml/directory.go
+++ b/pkg/diffyml/directory.go
@@ -228,7 +228,7 @@ func runDirectory(cfg *CLIConfig, rc *RunConfig, fromDir, toDir string) *ExitRes
 	// Apply color configuration
 	colorMode, _ := ParseColorMode(cfg.Color)
 	trueColorMode, _ := ParseColorMode(cfg.TrueColor)
-	colorCfg := NewColorConfig(colorMode, trueColorMode == ColorModeOn, cfg.FixedWidth)
+	colorCfg := NewColorConfig(colorMode, trueColorMode == ColorModeAlways, cfg.FixedWidth)
 	colorCfg.DetectTerminal()
 	colorCfg.ToFormatOptions(formatOpts)
 

--- a/pkg/diffyml/directory_test.go
+++ b/pkg/diffyml/directory_test.go
@@ -508,7 +508,7 @@ func TestFormatFileHeader_EndsWithNewline(t *testing.T) {
 func TestRunDirectory_IdenticalFiles_Exit0(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -530,7 +530,7 @@ func TestRunDirectory_IdenticalFiles_Exit0(t *testing.T) {
 func TestRunDirectory_ModifiedFile_Exit1(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -556,7 +556,7 @@ func TestRunDirectory_ModifiedFile_Exit1(t *testing.T) {
 func TestRunDirectory_AddedFile(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -582,7 +582,7 @@ func TestRunDirectory_AddedFile(t *testing.T) {
 func TestRunDirectory_RemovedFile(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -608,7 +608,7 @@ func TestRunDirectory_RemovedFile(t *testing.T) {
 func TestRunDirectory_MixedFiles(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -643,7 +643,7 @@ func TestRunDirectory_MixedFiles(t *testing.T) {
 func TestRunDirectory_NoDiffs_NoSetExitCode_Exit0(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = false
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -663,7 +663,7 @@ func TestRunDirectory_NoDiffs_NoSetExitCode_Exit0(t *testing.T) {
 func TestRunDirectory_EmptyDirectories_Exit0(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -681,7 +681,7 @@ func TestRunDirectory_OmitHeader_SuppressesSummaryButKeepsFileHeaders(t *testing
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
 	cfg.OmitHeader = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -705,7 +705,7 @@ func TestRunDirectory_OmitHeader_SuppressesSummaryButKeepsFileHeaders(t *testing
 func TestRunDirectory_ParseError_ContinuesProcessing(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -734,7 +734,7 @@ func TestRunDirectory_ParseError_ContinuesProcessing(t *testing.T) {
 func TestRunDirectory_ParseError_OnlyErrors_Exit255(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -756,7 +756,7 @@ func TestRunDirectory_ParseError_OnlyErrors_Exit255(t *testing.T) {
 func TestRunDirectory_IgnoreOrderChanges(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.IgnoreOrderChanges = true
 
 	rc := NewRunConfig()
@@ -782,7 +782,7 @@ func TestRunDirectory_IgnoreOrderChanges(t *testing.T) {
 func TestRunDirectory_FilterFlag(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Filter = []string{"config.a"}
 
 	rc := NewRunConfig()
@@ -812,7 +812,7 @@ func TestRunDirectory_FilterFlag(t *testing.T) {
 func TestRunDirectory_ExcludeFlag(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Exclude = []string{"config.secret"}
 
 	rc := NewRunConfig()
@@ -842,7 +842,7 @@ func TestRunDirectory_ExcludeFlag(t *testing.T) {
 func TestRunDirectory_OutputFormat_Compact(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "compact"
 
 	rc := NewRunConfig()
@@ -867,7 +867,7 @@ func TestRunDirectory_OutputFormat_Compact(t *testing.T) {
 func TestRunDirectory_OutputFormat_Brief(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "brief"
 
 	rc := NewRunConfig()
@@ -892,7 +892,7 @@ func TestRunDirectory_OutputFormat_Brief(t *testing.T) {
 func TestRunDirectory_OutputFormat_GitHub(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "github"
 
 	rc := NewRunConfig()
@@ -917,7 +917,7 @@ func TestRunDirectory_OutputFormat_GitHub(t *testing.T) {
 func TestRunDirectory_SwapDirectories(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Swap = true
 	cfg.Output = "compact"
 
@@ -943,7 +943,7 @@ func TestRunDirectory_SwapDirectories(t *testing.T) {
 func TestRunDirectory_MultipleFilesWithFilter(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Filter = []string{"name"}
 
 	rc := NewRunConfig()
@@ -985,7 +985,7 @@ func TestRunDirectory_MultipleFilesWithFilter(t *testing.T) {
 func TestRunDirectory_ExcludeAllDiffs_Exit0(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Exclude = []string{"key"}
 
 	rc := NewRunConfig()
@@ -1008,7 +1008,7 @@ func TestRunDirectory_ExcludeAllDiffs_Exit0(t *testing.T) {
 func TestRunDirectory_GitLab_SingleJSONArray(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1039,7 +1039,7 @@ func TestRunDirectory_GitLab_SingleJSONArray(t *testing.T) {
 func TestRunDirectory_GitLab_NoFileHeaders(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1065,7 +1065,7 @@ func TestRunDirectory_GitLab_NoFileHeaders(t *testing.T) {
 func TestRunDirectory_GitLab_EmptyProducesEmptyArray(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1090,7 +1090,7 @@ func TestRunDirectory_GitLab_EmptyProducesEmptyArray(t *testing.T) {
 func TestRunDirectory_GitLab_EmptyDirectoriesProducesEmptyArray(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1113,7 +1113,7 @@ func TestRunDirectory_GitLab_EmptyDirectoriesProducesEmptyArray(t *testing.T) {
 func TestRunDirectory_GitLab_LocationPathIsFilePath(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1144,7 +1144,7 @@ func TestRunDirectory_GitLab_LocationPathIsFilePath(t *testing.T) {
 func TestRunDirectory_GitLab_DescriptionIncludesFilename(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1174,7 +1174,7 @@ func TestRunDirectory_GitLab_DescriptionIncludesFilename(t *testing.T) {
 func TestRunDirectory_GitLab_UniqueFingerprintsAcrossFiles(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1207,7 +1207,7 @@ func TestRunDirectory_GitLab_UniqueFingerprintsAcrossFiles(t *testing.T) {
 func TestRunDirectory_GitLab_StripsDotSlashFromPairName(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1235,7 +1235,7 @@ func TestRunDirectory_NonGitLab_StillHasFileHeaders(t *testing.T) {
 		t.Run(format, func(t *testing.T) {
 			cfg := NewCLIConfig()
 			cfg.SetExitCode = true
-			cfg.Color = "off"
+			cfg.Color = "never"
 			cfg.Output = format
 
 			rc := NewRunConfig()
@@ -1260,7 +1260,7 @@ func TestRunDirectory_GitLab_ExitCodePrecedence(t *testing.T) {
 	// When diffs exist alongside errors, diffs take precedence
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1282,7 +1282,7 @@ func TestRunDirectory_GitLab_ExitCodePrecedence(t *testing.T) {
 func TestRunDirectory_GitLab_OnlyErrors_Exit255(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitlab"
 
 	rc := NewRunConfig()
@@ -1315,7 +1315,7 @@ func TestRunDirectory_NonGitLab_FileHeadersPresent(t *testing.T) {
 		t.Run(format, func(t *testing.T) {
 			cfg := NewCLIConfig()
 			cfg.SetExitCode = true
-			cfg.Color = "off"
+			cfg.Color = "never"
 			cfg.Output = format
 
 			rc := NewRunConfig()
@@ -1402,7 +1402,7 @@ func TestRunDirectory_NonGitLab_PerFileOutput(t *testing.T) {
 	// (not a single aggregated output) in directory mode.
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "compact"
 
 	rc := NewRunConfig()
@@ -1436,7 +1436,7 @@ func TestRunDirectory_DetailedFormatter_FileHeadersInDirectoryMode(t *testing.T)
 	// Detailed formatter specifically should have file headers in directory mode.
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "detailed"
 
 	rc := NewRunConfig()
@@ -1462,7 +1462,7 @@ func TestRunDirectory_DetailedFormatter_FileHeadersInDirectoryMode(t *testing.T)
 func TestRunDirectory_GitHub_StructuredOutput(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "github"
 
 	rc := NewRunConfig()
@@ -1506,7 +1506,7 @@ func TestRunDirectory_GitHub_StructuredOutput(t *testing.T) {
 func TestRunDirectory_GitHub_EmptyProducesEmptyString(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "github"
 
 	rc := NewRunConfig()
@@ -1531,7 +1531,7 @@ func TestRunDirectory_GitHub_EmptyProducesEmptyString(t *testing.T) {
 func TestRunDirectory_Gitea_StructuredOutput(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "gitea"
 
 	rc := NewRunConfig()
@@ -1563,7 +1563,7 @@ func TestRunDirectory_Gitea_StructuredOutput(t *testing.T) {
 func TestRunDirectory_GitHub_StripsDotSlashFromPairName(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.SetExitCode = true
-	cfg.Color = "off"
+	cfg.Color = "never"
 	cfg.Output = "github"
 
 	rc := NewRunConfig()

--- a/pkg/diffyml/formatter_test.go
+++ b/pkg/diffyml/formatter_test.go
@@ -243,31 +243,31 @@ func TestConvertToGoPatchPath(t *testing.T) {
 
 // Color configuration tests
 
-func TestColorMode_On(t *testing.T) {
-	mode := ColorModeOn
-	// ColorModeOn should always enable color
+func TestColorMode_Always(t *testing.T) {
+	mode := ColorModeAlways
+	// ColorModeAlways should always enable color
 	enabled := ResolveColorMode(mode, false)
 	if !enabled {
-		t.Error("ColorModeOn should enable color even when not a terminal")
+		t.Error("ColorModeAlways should enable color even when not a terminal")
 	}
 
 	enabled = ResolveColorMode(mode, true)
 	if !enabled {
-		t.Error("ColorModeOn should enable color when terminal")
+		t.Error("ColorModeAlways should enable color when terminal")
 	}
 }
 
-func TestColorMode_Off(t *testing.T) {
-	mode := ColorModeOff
-	// ColorModeOff should never enable color
+func TestColorMode_Never(t *testing.T) {
+	mode := ColorModeNever
+	// ColorModeNever should never enable color
 	enabled := ResolveColorMode(mode, true)
 	if enabled {
-		t.Error("ColorModeOff should disable color even when terminal")
+		t.Error("ColorModeNever should disable color even when terminal")
 	}
 
 	enabled = ResolveColorMode(mode, false)
 	if enabled {
-		t.Error("ColorModeOff should disable color when not a terminal")
+		t.Error("ColorModeNever should disable color when not a terminal")
 	}
 }
 
@@ -292,11 +292,11 @@ func TestParseColorMode_Valid(t *testing.T) {
 		input    string
 		expected ColorMode
 	}{
-		{"on", ColorModeOn},
-		{"ON", ColorModeOn},
-		{"On", ColorModeOn},
-		{"off", ColorModeOff},
-		{"OFF", ColorModeOff},
+		{"always", ColorModeAlways},
+		{"ALWAYS", ColorModeAlways},
+		{"Always", ColorModeAlways},
+		{"never", ColorModeNever},
+		{"NEVER", ColorModeNever},
 		{"auto", ColorModeAuto},
 		{"AUTO", ColorModeAuto},
 	}
@@ -382,7 +382,7 @@ func TestColorConfig_DisableColorForNonTerminal(t *testing.T) {
 }
 
 func TestColorConfig_TrueColor(t *testing.T) {
-	cfg := NewColorConfig(ColorModeOn, true, 0)
+	cfg := NewColorConfig(ColorModeAlways, true, 0)
 	cfg.SetIsTerminal(true)
 
 	if !cfg.ShouldUseTrueColor() {
@@ -391,7 +391,7 @@ func TestColorConfig_TrueColor(t *testing.T) {
 }
 
 func TestColorConfig_TrueColorDisabled(t *testing.T) {
-	cfg := NewColorConfig(ColorModeOn, false, 0)
+	cfg := NewColorConfig(ColorModeAlways, false, 0)
 	cfg.SetIsTerminal(true)
 
 	if cfg.ShouldUseTrueColor() {
@@ -400,7 +400,7 @@ func TestColorConfig_TrueColorDisabled(t *testing.T) {
 }
 
 func TestColorConfig_Width(t *testing.T) {
-	cfg := NewColorConfig(ColorModeOn, false, 100)
+	cfg := NewColorConfig(ColorModeAlways, false, 100)
 
 	width := cfg.GetWidth()
 	if width != 100 {
@@ -409,7 +409,7 @@ func TestColorConfig_Width(t *testing.T) {
 }
 
 func TestColorConfig_DefaultWidth(t *testing.T) {
-	cfg := NewColorConfig(ColorModeOn, false, 0)
+	cfg := NewColorConfig(ColorModeAlways, false, 0)
 
 	width := cfg.GetWidth()
 	if width <= 0 {


### PR DESCRIPTION
## What

Rename `--color` and `--truecolor` accepted values from `on/off/auto` to `always/never/auto`.

## Why

The GNU convention (`always/never/auto`) is used by `ls`, `grep`, `git`, `ripgrep`, `cargo`, and most other CLI tools. Aligning with this standard improves discoverability and familiarity for users.

## How

- Rename constants `ColorModeOn` → `ColorModeAlways`, `ColorModeOff` → `ColorModeNever`
- Update `ParseColorMode()` to accept `always`/`never` instead of `on`/`off`
- Update CLI flag descriptions, `--help` output, validation error messages, and README
- Update all test files to use the new values (8 files changed, 96 insertions, 96 deletions)

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `doc:`, `chore:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

This is a breaking change for users passing `--color on` or `--color off`. The old values will now produce a validation error with a clear message listing valid options.