### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repo
+* @szhekpisov


### PR DESCRIPTION
## What

Add a `CODEOWNERS` file to assign default code ownership.

## Why

Ensures all PRs automatically request review from the repository owner.

## How

Added `.github/CODEOWNERS` with `@szhekpisov` as the default owner for all files.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `doc:`, `chore:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

No code changes — metadata only.