### PR TITLE
chore: fix zizmor CI failure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,6 +35,9 @@ jobs:
 
   zizmor:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## What

Fix the Security & Static Analysis workflow failure on `main` (zizmor job).

## Why

The zizmor job fails for two reasons:
1. Missing `security-events: write` permission — SARIF upload to GitHub Code Scanning fails with "Resource not accessible by integration"
2. zizmor v1.22.0 flags `dependabot-cooldown` findings for both entries in `.github/dependabot.yml`

## How

- Add job-level `permissions: { contents: read, security-events: write }` to the `zizmor` job
- Add `cooldown: { default-days: 7 }` to both Dependabot update entries

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `doc:`, `chore:`)
- [x] `make ci` passes locally
- [ ] New/changed behavior covered by tests
- [ ] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

CI-only changes — no application code modified. Test/coverage items are N/A.