### PR TITLE
chore: add SLSA provenance generation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # zizmor: ignore[unpinned-uses]
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
       upload-assets: true


### PR DESCRIPTION
## What

Add SLSA3 provenance attestation to release artifacts.

## Why

OpenSSF Scorecard flags that release artifacts (v1.0.0, v1.1.0) lack provenance. Adding provenance improves supply-chain security and the Scorecard score.

## How

- Extract SHA256 hashes from GoReleaser's `checksums.txt` output and expose them as a job output
- Add a new `provenance` job that calls `slsa-framework/slsa-github-generator` generic SLSA3 generator (`generator_generic_slsa3.yml@v2.1.0`)
- The provenance job uploads `multiple.intoto.jsonl` attestation to each GitHub release
- Referenced by semantic version tag (not SHA) — required by `slsa-verifier` for provenance verification

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `doc:`, `chore:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

The SLSA reusable workflow is pinned by tag (`@v2.1.0`) rather than SHA. This is intentional — `slsa-verifier` validates the workflow source URI against version tags, so SHA pinning would break provenance verification. zizmor will flag this; it's a known exception.