### PR TITLE
feat: add AI-powered summary of YAML differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Structural diff for YAML files. Understands YAML semantics and detects Kubernete
 - **Certificate inspection** — inspects and compares embedded x509 certificates
 - **Directory comparison** — compare two directories of YAML files; works as `KUBECTL_EXTERNAL_DIFF`
 - **Chroot navigation** — focus comparison on a specific YAML subtree
+- ⭐ **AI-powered summaries** ⭐ — natural language summaries of changes via Anthropic API
 
 ## Installation
 
@@ -134,6 +135,25 @@ Use `-s` / `--set-exit-code` to set the exit code based on differences:
 diffyml -s before.yaml after.yaml || echo "Config drift detected"
 ```
 
+### AI Summary
+
+Generate a natural language summary of changes using the Anthropic API:
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Append AI summary after the diff output
+diffyml --summary old.yaml new.yaml
+
+# Use with brief format — replaces brief output with AI summary
+diffyml --summary -o brief old.yaml new.yaml
+
+# Use a different model
+diffyml --summary --summary-model claude-sonnet-4-5-20250514 old.yaml new.yaml
+```
+
+The summary is appended after the standard diff output. If the API call fails, a warning is printed to stderr and the diff output is preserved. The exit code is never affected by summary success or failure.
+
 ### All Flags
 
 <details>
@@ -188,6 +208,13 @@ diffyml -s before.yaml after.yaml || echo "Config drift detected"
 | `--chroot-of-from <path>` | Change root level for the from file only |
 | `--chroot-of-to <path>` | Change root level for the to file only |
 | `--chroot-list-to-documents` | Treat chroot list as separate documents |
+
+**AI Summary**
+
+| Flag | Description |
+|------|-------------|
+| `-S, --summary` | Generate AI-powered natural language summary (requires `ANTHROPIC_API_KEY`) |
+| `--summary-model <model>` | Model for AI summary (default `claude-haiku-4-5-20251001`) |
 
 **Other**
 

--- a/pkg/diffyml/cli_test.go
+++ b/pkg/diffyml/cli_test.go
@@ -1796,3 +1796,730 @@ func TestRun_GitLab_FallbackOnParentTraversingPath(t *testing.T) {
 		t.Errorf("expected warning on stderr when using absolute path, stderr: %q", stderr.String())
 	}
 }
+
+// --- Task 2.1: Summary CLI flags and API key validation ---
+
+func TestCLIConfig_ParseArgs_SummaryFlag(t *testing.T) {
+	cfg := NewCLIConfig()
+	args := []string{"--summary", "from.yaml", "to.yaml"}
+
+	err := cfg.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.Summary {
+		t.Error("expected Summary=true with --summary flag")
+	}
+}
+
+func TestCLIConfig_ParseArgs_SummaryShortFlag(t *testing.T) {
+	cfg := NewCLIConfig()
+	args := []string{"-S", "from.yaml", "to.yaml"}
+
+	err := cfg.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !cfg.Summary {
+		t.Error("expected Summary=true with -S flag")
+	}
+}
+
+func TestCLIConfig_ParseArgs_SummaryModelFlag(t *testing.T) {
+	cfg := NewCLIConfig()
+	args := []string{"--summary-model", "claude-sonnet-4-20250514", "from.yaml", "to.yaml"}
+
+	err := cfg.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.SummaryModel != "claude-sonnet-4-20250514" {
+		t.Errorf("expected SummaryModel='claude-sonnet-4-20250514', got %q", cfg.SummaryModel)
+	}
+}
+
+func TestCLIConfig_ParseArgs_SummaryDefaultOff(t *testing.T) {
+	cfg := NewCLIConfig()
+	args := []string{"from.yaml", "to.yaml"}
+
+	err := cfg.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Summary {
+		t.Error("expected Summary=false by default")
+	}
+	if cfg.SummaryModel != "" {
+		t.Errorf("expected SummaryModel='' by default, got %q", cfg.SummaryModel)
+	}
+}
+
+func TestCLIConfig_Validate_SummaryWithoutAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	cfg := NewCLIConfig()
+	cfg.FromFile = "from.yaml"
+	cfg.ToFile = "to.yaml"
+	cfg.Summary = true
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("expected error when --summary is set but ANTHROPIC_API_KEY is missing")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("error should mention ANTHROPIC_API_KEY, got: %v", err)
+	}
+}
+
+func TestCLIConfig_Validate_SummaryWithAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key-123")
+
+	cfg := NewCLIConfig()
+	cfg.FromFile = "from.yaml"
+	cfg.ToFile = "to.yaml"
+	cfg.Summary = true
+
+	err := cfg.Validate()
+	if err != nil {
+		t.Errorf("expected no error when --summary with API key set, got: %v", err)
+	}
+}
+
+func TestCLIConfig_Validate_NoSummaryNoAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	cfg := NewCLIConfig()
+	cfg.FromFile = "from.yaml"
+	cfg.ToFile = "to.yaml"
+	cfg.Summary = false
+
+	err := cfg.Validate()
+	if err != nil {
+		t.Errorf("expected no error when --summary is not set, got: %v", err)
+	}
+}
+
+func TestCLI_Usage_ContainsSummaryFlags(t *testing.T) {
+	cfg := NewCLIConfig()
+	usage := cfg.Usage()
+
+	if !strings.Contains(usage, "--summary") {
+		t.Error("Usage() should contain --summary flag")
+	}
+	if !strings.Contains(usage, "-S") {
+		t.Error("Usage() should contain -S short flag")
+	}
+	if !strings.Contains(usage, "--summary-model") {
+		t.Error("Usage() should contain --summary-model flag")
+	}
+}
+
+// --- Task 3.1: Wire summarizer into single-file comparison mode ---
+
+func TestRun_WithSummary_AppendsSummaryToOutput(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	// Start a mock Anthropic API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request
+		if r.Header.Get("x-api-key") != "test-key" {
+			t.Error("expected x-api-key header")
+		}
+
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"The key value was changed from value1 to value2."}]}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "compact"
+	cfg.Summary = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+
+	output := stdout.String()
+	// Should contain standard diff output
+	if !strings.Contains(output, "key") {
+		t.Error("expected standard diff output containing 'key'")
+	}
+	// Should contain AI summary header and text
+	if !strings.Contains(output, "AI Summary:") {
+		t.Errorf("expected 'AI Summary:' header in output, got: %s", output)
+	}
+	if !strings.Contains(output, "value was changed") {
+		t.Errorf("expected summary text in output, got: %s", output)
+	}
+}
+
+func TestRun_WithSummary_NoDiffs_NoAPICall(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml := "key: value\n"
+
+	apiCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"Summary."}]}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Summary = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml)
+	rc.ToContent = []byte(yaml)
+	rc.SummaryAPIURL = server.URL
+
+	Run(cfg, rc)
+
+	if apiCalled {
+		t.Error("API should not be called when there are no differences")
+	}
+}
+
+func TestRun_WithSummary_APIFailure_WarningOnStderr(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprint(w, `{"type":"error","error":{"type":"api_error","message":"internal error"}}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "compact"
+	cfg.Summary = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+
+	// Exit code should not be affected by summary failure
+	if result.Code != ExitCodeSuccess {
+		t.Errorf("expected exit code %d, got %d", ExitCodeSuccess, result.Code)
+	}
+	// Standard diff output should still be present
+	if !strings.Contains(stdout.String(), "key") {
+		t.Error("expected standard diff output despite API failure")
+	}
+	// Warning on stderr
+	if !strings.Contains(stderr.String(), "Warning") {
+		t.Errorf("expected warning on stderr, got: %s", stderr.String())
+	}
+	// No AI Summary in stdout
+	if strings.Contains(stdout.String(), "AI Summary:") {
+		t.Error("expected no AI Summary header on API failure")
+	}
+}
+
+func TestRun_WithSummary_PreservesExitCode(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"Summary."}]}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Summary = true
+	cfg.SetExitCode = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+	// Exit code 1 should be preserved even with summary
+	if result.Code != ExitCodeDifferences {
+		t.Errorf("expected exit code %d with --set-exit-code, got %d", ExitCodeDifferences, result.Code)
+	}
+}
+
+func TestRun_WithSummary_APIFailure_PreservesExitCode(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprint(w, `{"type":"error","error":{"type":"api_error","message":"fail"}}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Summary = true
+	cfg.SetExitCode = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+	// Exit code should still be 1 (differences) even on API failure
+	if result.Code != ExitCodeDifferences {
+		t.Errorf("expected exit code %d with --set-exit-code and API failure, got %d",
+			ExitCodeDifferences, result.Code)
+	}
+}
+
+func TestRun_WithoutSummary_NoAPICall(t *testing.T) {
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	apiCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Summary = false
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	Run(cfg, rc)
+
+	if apiCalled {
+		t.Error("API should not be called when --summary is not set")
+	}
+}
+
+// --- Task 3.3: Brief format special case ---
+
+func TestRun_BriefSummary_ReplacesOutput(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"The key was updated."}]}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "brief"
+	cfg.Summary = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+
+	output := stdout.String()
+	// Should contain AI summary
+	if !strings.Contains(output, "AI Summary:") {
+		t.Errorf("expected AI Summary header, got: %s", output)
+	}
+	if !strings.Contains(output, "The key was updated.") {
+		t.Errorf("expected summary text, got: %s", output)
+	}
+	// Should NOT contain brief format markers (± or "modified")
+	if strings.Contains(output, "±") {
+		t.Errorf("expected brief output to be suppressed, but found '±' in: %s", output)
+	}
+}
+
+func TestRun_BriefSummary_FallbackOnAPIFailure(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		fmt.Fprint(w, `{"type":"error","error":{"type":"api_error","message":"fail"}}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "brief"
+	cfg.Summary = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+
+	output := stdout.String()
+	// Should fall back to brief output
+	if !strings.Contains(output, "±") && !strings.Contains(output, "modified") {
+		t.Errorf("expected brief fallback output on API failure, got: %s", output)
+	}
+	// Warning on stderr
+	if !strings.Contains(stderr.String(), "Warning") {
+		t.Errorf("expected warning on stderr, got: %s", stderr.String())
+	}
+	// No AI Summary header
+	if strings.Contains(output, "AI Summary:") {
+		t.Error("expected no AI Summary header on API failure")
+	}
+}
+
+func TestRun_BriefSummary_NoDiffs_ShowsStandardOutput(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml := "key: value\n"
+
+	apiCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "brief"
+	cfg.Summary = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml)
+	rc.ToContent = []byte(yaml)
+	rc.SummaryAPIURL = server.URL
+
+	Run(cfg, rc)
+
+	if apiCalled {
+		t.Error("API should not be called when there are no differences")
+	}
+}
+
+// --- Task 4.1: End-to-end CLI flag and validation tests ---
+
+func TestRun_SummaryValidation_NoAPIKey_ExitCode255(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	cfg := NewCLIConfig()
+	cfg.FromFile = "from.yaml"
+	cfg.ToFile = "to.yaml"
+	cfg.Summary = true
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+
+	result := Run(cfg, rc)
+	if result.Code != ExitCodeError {
+		t.Errorf("expected exit code %d (255) when --summary without API key, got %d", ExitCodeError, result.Code)
+	}
+	if !strings.Contains(stderr.String(), "ANTHROPIC_API_KEY") {
+		t.Errorf("expected error mentioning ANTHROPIC_API_KEY, got: %s", stderr.String())
+	}
+}
+
+func TestRun_SummaryValidation_NoAPIKey_ParseAndRun(t *testing.T) {
+	// End-to-end: parse args then run
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	cfg := NewCLIConfig()
+	args := []string{"--summary", "from.yaml", "to.yaml"}
+	if err := cfg.ParseArgs(args); err != nil {
+		t.Fatalf("failed to parse args: %v", err)
+	}
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+
+	result := Run(cfg, rc)
+	if result.Code != ExitCodeError {
+		t.Errorf("expected exit code 255, got %d", result.Code)
+	}
+}
+
+func TestRun_SummaryModelFlag_ParseAndRun(t *testing.T) {
+	// End-to-end: parse --summary-model flag then verify it's used in API call
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	var receivedModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if model, ok := req["model"].(string); ok {
+			receivedModel = model
+		}
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"Summary."}]}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	args := []string{"--summary", "--summary-model", "claude-sonnet-4-20250514", "from.yaml", "to.yaml"}
+	if err := cfg.ParseArgs(args); err != nil {
+		t.Fatalf("failed to parse args: %v", err)
+	}
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte("key: value1\n")
+	rc.ToContent = []byte("key: value2\n")
+	rc.SummaryAPIURL = server.URL
+
+	Run(cfg, rc)
+
+	if receivedModel != "claude-sonnet-4-20250514" {
+		t.Errorf("expected model 'claude-sonnet-4-20250514' in API request, got %q", receivedModel)
+	}
+}
+
+func TestRun_WithSummary_AllFormats(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"Summary text."}]}`)
+	}))
+	defer server.Close()
+
+	formats := []string{"compact", "github", "gitlab", "gitea", "detailed"}
+
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			cfg := NewCLIConfig()
+			cfg.Output = format
+			cfg.Summary = true
+			cfg.Color = "never"
+
+			rc := NewRunConfig()
+			var stdout, stderr strings.Builder
+			rc.Stdout = &stdout
+			rc.Stderr = &stderr
+			rc.FromContent = []byte(yaml1)
+			rc.ToContent = []byte(yaml2)
+			rc.SummaryAPIURL = server.URL
+
+			result := Run(cfg, rc)
+			if result.Err != nil {
+				t.Fatalf("unexpected error for format %s: %v", format, result.Err)
+			}
+
+			output := stdout.String()
+			if !strings.Contains(output, "AI Summary:") {
+				t.Errorf("expected AI Summary header for format %s, got: %s", format, output)
+			}
+		})
+	}
+}
+
+// --- Task 4.2: End-to-end integration tests for summary flows ---
+
+func TestRun_WithSummary_ColorEnabled(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "key: value1\n"
+	yaml2 := "key: value2\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"Colored summary."}]}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "compact"
+	cfg.Summary = true
+	cfg.Color = "always"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+	if result.Err != nil {
+		t.Fatalf("unexpected error: %v", result.Err)
+	}
+
+	output := stdout.String()
+	// Should contain colored AI Summary header
+	if !strings.Contains(output, colorCyan) {
+		t.Errorf("expected cyan color in AI Summary header with color=always, got: %s", output)
+	}
+	if !strings.Contains(output, styleBold) {
+		t.Errorf("expected bold style in AI Summary header with color=always, got: %s", output)
+	}
+	if !strings.Contains(output, "AI Summary:") {
+		t.Errorf("expected AI Summary header, got: %s", output)
+	}
+}
+
+func TestRun_WithSummary_WithFilter_OnlyFilteredDiffsSent(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml1 := "config:\n  a: 1\n  b: 2\n"
+	yaml2 := "config:\n  a: 10\n  b: 20\n"
+
+	var receivedPrompt string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Messages []struct {
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if len(req.Messages) > 0 {
+			receivedPrompt = req.Messages[0].Content
+		}
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"content":[{"type":"text","text":"Filtered summary."}]}`)
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "compact"
+	cfg.Summary = true
+	cfg.Color = "never"
+	cfg.Filter = []string{"config.a"}
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml1)
+	rc.ToContent = []byte(yaml2)
+	rc.SummaryAPIURL = server.URL
+
+	Run(cfg, rc)
+
+	// Should contain config.a in prompt
+	if !strings.Contains(receivedPrompt, "config.a") {
+		t.Errorf("expected config.a in API prompt, got: %s", receivedPrompt)
+	}
+	// Should NOT contain config.b in prompt (filtered out)
+	if strings.Contains(receivedPrompt, "config.b") {
+		t.Errorf("expected config.b NOT in API prompt (filtered), got: %s", receivedPrompt)
+	}
+	// Output should contain the summary
+	if !strings.Contains(stdout.String(), "AI Summary:") {
+		t.Errorf("expected AI Summary in output, got: %s", stdout.String())
+	}
+}
+
+func TestRun_WithSummary_BriefNoDiffs_StandardOutput(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	yaml := "key: value\n"
+
+	apiCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+	}))
+	defer server.Close()
+
+	cfg := NewCLIConfig()
+	cfg.Output = "brief"
+	cfg.Summary = true
+	cfg.Color = "never"
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FromContent = []byte(yaml)
+	rc.ToContent = []byte(yaml)
+	rc.SummaryAPIURL = server.URL
+
+	result := Run(cfg, rc)
+	if result.Code != ExitCodeSuccess {
+		t.Errorf("expected exit code 0, got %d", result.Code)
+	}
+	if apiCalled {
+		t.Error("API should not be called when there are no differences (brief+summary)")
+	}
+	// Standard brief output should be shown (no diffs, so formatter handles it)
+	if strings.Contains(stdout.String(), "AI Summary:") {
+		t.Error("should not show AI Summary when there are no diffs")
+	}
+}

--- a/pkg/diffyml/color.go
+++ b/pkg/diffyml/color.go
@@ -169,6 +169,7 @@ const (
 	colorRed    = "\033[31m"
 	colorGreen  = "\033[32m"
 	colorYellow = "\033[33m"
+	colorCyan   = "\033[36m"
 	colorWhite  = "\033[37m"
 	colorGray   = "\033[90m" // Bright black
 )

--- a/pkg/diffyml/summarizer.go
+++ b/pkg/diffyml/summarizer.go
@@ -1,0 +1,304 @@
+// summarizer.go - AI-powered summary generation for YAML differences.
+//
+// Uses the Anthropic Messages API to generate natural language summaries.
+// Key types: Summarizer, httpDoer interface.
+// Key functions: NewSummarizer, Summarize, buildPrompt, serializeValue.
+package diffyml
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultModel     = "claude-haiku-4-5-20251001"
+	anthropicAPIURL  = "https://api.anthropic.com/v1/messages"
+	anthropicVersion = "2023-06-01"
+	maxPromptLen     = 8000
+	summaryTimeout   = 30 * time.Second
+)
+
+// httpDoer abstracts HTTP request execution for testability.
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Summarizer generates AI-powered summaries of YAML differences.
+type Summarizer struct {
+	client httpDoer
+	apiKey string
+	model  string
+	apiURL string // overridable for testing; defaults to anthropicAPIURL
+}
+
+// NewSummarizer creates a summarizer with the specified model.
+// If model is empty, defaults to claude-haiku-4-5-20251001.
+// Reads ANTHROPIC_API_KEY from the environment.
+func NewSummarizer(model string) *Summarizer {
+	if model == "" {
+		model = defaultModel
+	}
+	return &Summarizer{
+		client: &http.Client{},
+		apiKey: os.Getenv("ANTHROPIC_API_KEY"),
+		model:  model,
+		apiURL: anthropicAPIURL,
+	}
+}
+
+// NewSummarizerWithClient creates a summarizer with an injected httpDoer.
+// Used in tests to supply a mock HTTP client.
+func NewSummarizerWithClient(model string, apiKey string, client httpDoer) *Summarizer {
+	if model == "" {
+		model = defaultModel
+	}
+	return &Summarizer{
+		client: client,
+		apiKey: apiKey,
+		model:  model,
+		apiURL: anthropicAPIURL,
+	}
+}
+
+// messagesRequest is the Anthropic Messages API request body.
+type messagesRequest struct {
+	Model     string         `json:"model"`
+	MaxTokens int            `json:"max_tokens"`
+	System    string         `json:"system"`
+	Messages  []messageParam `json:"messages"`
+}
+
+type messageParam struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// messagesResponse is the relevant subset of the Anthropic Messages API response.
+type messagesResponse struct {
+	Content []contentBlock `json:"content"`
+	Error   *apiError      `json:"error,omitempty"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type apiError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// Summarize generates a natural language summary of the given differences.
+// Returns the summary text or an error if the API call fails.
+func (s *Summarizer) Summarize(ctx context.Context, groups []DiffGroup) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, summaryTimeout)
+	defer cancel()
+
+	prompt := buildPrompt(groups)
+
+	reqBody := messagesRequest{
+		Model:     s.model,
+		MaxTokens: 512,
+		System:    systemPrompt(),
+		Messages:  []messageParam{{Role: "user", Content: prompt}},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	// Check context before making the request
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", fmt.Errorf("request timed out")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", s.apiURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", s.apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var result messagesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("unexpected response format")
+	}
+
+	// Handle HTTP error status codes
+	switch {
+	case resp.StatusCode == 401:
+		return "", fmt.Errorf("invalid API key")
+	case resp.StatusCode == 429:
+		return "", fmt.Errorf("rate limited")
+	case resp.StatusCode >= 500:
+		msg := "unknown error"
+		if result.Error != nil && result.Error.Message != "" {
+			msg = result.Error.Message
+		}
+		return "", fmt.Errorf("server error: %s", msg)
+	case resp.StatusCode != 200:
+		msg := fmt.Sprintf("HTTP %d", resp.StatusCode)
+		if result.Error != nil && result.Error.Message != "" {
+			msg = result.Error.Message
+		}
+		return "", fmt.Errorf("API error: %s", msg)
+	}
+
+	// Extract text from first text content block
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			if block.Text == "" {
+				return "", fmt.Errorf("unexpected response format: empty text")
+			}
+			return block.Text, nil
+		}
+	}
+
+	return "", fmt.Errorf("unexpected response format: no text content")
+}
+
+// diffTypeLabel returns the prompt label for a DiffType.
+func diffTypeLabel(dt DiffType) string {
+	switch dt {
+	case DiffAdded:
+		return "ADDED"
+	case DiffRemoved:
+		return "REMOVED"
+	case DiffModified:
+		return "MODIFIED"
+	case DiffOrderChanged:
+		return "ORDER_CHANGED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// buildPrompt serializes DiffGroups into structured text for the API.
+func buildPrompt(groups []DiffGroup) string {
+	var sb strings.Builder
+	totalLen := 0
+	groupsWritten := 0
+	totalGroups := len(groups)
+	totalRemainingDiffs := 0
+
+	for _, group := range groups {
+		// Serialize this group into a temporary buffer
+		var groupBuf strings.Builder
+		fmt.Fprintf(&groupBuf, "File: %s\n", group.FilePath)
+		for _, diff := range group.Diffs {
+			from := serializeValue(diff.From)
+			to := serializeValue(diff.To)
+			fmt.Fprintf(&groupBuf, "- [%s] %s: %q → %q\n", diffTypeLabel(diff.Type), diff.Path, from, to)
+		}
+		groupBuf.WriteString("\n")
+
+		groupText := groupBuf.String()
+
+		// Check truncation before adding
+		if totalLen+len(groupText) > maxPromptLen && groupsWritten > 0 {
+			// Count remaining diffs
+			for _, g := range groups[groupsWritten:] {
+				totalRemainingDiffs += len(g.Diffs)
+			}
+			remainingFiles := totalGroups - groupsWritten
+			fmt.Fprintf(&sb, "... and %d more changes across %d more files (truncated)\n", totalRemainingDiffs, remainingFiles)
+			break
+		}
+
+		sb.WriteString(groupText)
+		totalLen += len(groupText)
+		groupsWritten++
+	}
+
+	return sb.String()
+}
+
+// serializeValue serializes a Difference.From or Difference.To value into a
+// human-readable string for prompt inclusion.
+func serializeValue(val interface{}) string {
+	if val == nil {
+		return "<none>"
+	}
+
+	switch v := val.(type) {
+	case *OrderedMap:
+		out, err := yaml.Marshal(orderedMapToGeneric(v))
+		if err != nil {
+			return fmt.Sprintf("%v", val)
+		}
+		return strings.TrimRight(string(out), "\n")
+	case map[string]interface{}, []interface{}:
+		out, err := yaml.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", val)
+		}
+		return strings.TrimRight(string(out), "\n")
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+// orderedMapToGeneric converts an OrderedMap to a yaml.v3-serializable
+// structure that preserves key order.
+func orderedMapToGeneric(om *OrderedMap) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for _, key := range om.Keys {
+		keyNode := &yaml.Node{Kind: yaml.ScalarNode, Value: key, Tag: "!!str"}
+		valNode := valueToYAMLNode(om.Values[key])
+		node.Content = append(node.Content, keyNode, valNode)
+	}
+	return node
+}
+
+// valueToYAMLNode converts a Go value to a yaml.Node for serialization.
+func valueToYAMLNode(val interface{}) *yaml.Node {
+	switch v := val.(type) {
+	case *OrderedMap:
+		return orderedMapToGeneric(v)
+	default:
+		n := &yaml.Node{}
+		_ = n.Encode(val)
+		return n
+	}
+}
+
+// systemPrompt returns the system prompt instructing the model on summary style.
+func systemPrompt() string {
+	return "You are a YAML diff summarizer. Given a list of structural differences between YAML files, produce a concise natural language summary (2-5 sentences). Focus on the most important changes and their likely impact. Do not repeat raw paths or values — describe the changes at a conceptual level. If changes span multiple files, mention the affected files."
+}
+
+// formatSummaryOutput formats the AI summary for display.
+func formatSummaryOutput(summary string, opts *FormatOptions) string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+
+	if opts != nil && opts.Color {
+		sb.WriteString(styleBold + colorCyan)
+		sb.WriteString("AI Summary:")
+		sb.WriteString(colorReset)
+	} else {
+		sb.WriteString("AI Summary:")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(summary)
+	sb.WriteString("\n")
+
+	return sb.String()
+}

--- a/pkg/diffyml/summarizer_test.go
+++ b/pkg/diffyml/summarizer_test.go
@@ -1,0 +1,469 @@
+package diffyml
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// --- mockHTTPDoer ---
+
+type mockHTTPDoer struct {
+	statusCode int
+	body       string
+	err        error
+	lastReq    *http.Request
+}
+
+func (m *mockHTTPDoer) Do(req *http.Request) (*http.Response, error) {
+	m.lastReq = req
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Body:       io.NopCloser(strings.NewReader(m.body)),
+	}, nil
+}
+
+// --- serializeValue tests ---
+
+func TestSerializeValue_Nil(t *testing.T) {
+	got := serializeValue(nil)
+	if got != "<none>" {
+		t.Errorf("serializeValue(nil) = %q, want %q", got, "<none>")
+	}
+}
+
+func TestSerializeValue_String(t *testing.T) {
+	got := serializeValue("hello")
+	if got != "hello" {
+		t.Errorf("serializeValue(\"hello\") = %q, want %q", got, "hello")
+	}
+}
+
+func TestSerializeValue_Int(t *testing.T) {
+	got := serializeValue(42)
+	if got != "42" {
+		t.Errorf("serializeValue(42) = %q, want %q", got, "42")
+	}
+}
+
+func TestSerializeValue_Bool(t *testing.T) {
+	got := serializeValue(true)
+	if got != "true" {
+		t.Errorf("serializeValue(true) = %q, want %q", got, "true")
+	}
+}
+
+func TestSerializeValue_Float(t *testing.T) {
+	got := serializeValue(3.14)
+	if got != "3.14" {
+		t.Errorf("serializeValue(3.14) = %q, want %q", got, "3.14")
+	}
+}
+
+func TestSerializeValue_OrderedMap(t *testing.T) {
+	om := NewOrderedMap()
+	om.Keys = []string{"name", "port"}
+	om.Values["name"] = "http"
+	om.Values["port"] = 80
+
+	got := serializeValue(om)
+	if !strings.Contains(got, "name: http") || !strings.Contains(got, "port: 80") {
+		t.Errorf("serializeValue(OrderedMap) = %q, want to contain name and port", got)
+	}
+}
+
+func TestSerializeValue_Map(t *testing.T) {
+	m := map[string]interface{}{"key": "value"}
+	got := serializeValue(m)
+	if !strings.Contains(got, "key: value") {
+		t.Errorf("serializeValue(map) = %q, want to contain 'key: value'", got)
+	}
+}
+
+func TestSerializeValue_Slice(t *testing.T) {
+	s := []interface{}{"a", "b", "c"}
+	got := serializeValue(s)
+	if !strings.Contains(got, "- a") || !strings.Contains(got, "- b") {
+		t.Errorf("serializeValue(slice) = %q, want to contain list items", got)
+	}
+}
+
+// --- buildPrompt tests ---
+
+func TestBuildPrompt_SingleFileAdded(t *testing.T) {
+	groups := []DiffGroup{
+		{
+			FilePath: "deploy.yaml",
+			Diffs: []Difference{
+				{Path: "spec.replicas", Type: DiffAdded, From: nil, To: 3},
+			},
+		},
+	}
+
+	got := buildPrompt(groups)
+
+	if !strings.Contains(got, "File: deploy.yaml") {
+		t.Errorf("buildPrompt missing file header, got: %s", got)
+	}
+	if !strings.Contains(got, "[ADDED]") {
+		t.Errorf("buildPrompt missing [ADDED] label, got: %s", got)
+	}
+	if !strings.Contains(got, "spec.replicas") {
+		t.Errorf("buildPrompt missing path, got: %s", got)
+	}
+	if !strings.Contains(got, "<none>") {
+		t.Errorf("buildPrompt missing <none> for nil From, got: %s", got)
+	}
+}
+
+func TestBuildPrompt_AllDiffTypes(t *testing.T) {
+	groups := []DiffGroup{
+		{
+			FilePath: "test.yaml",
+			Diffs: []Difference{
+				{Path: "a", Type: DiffAdded, From: nil, To: "new"},
+				{Path: "b", Type: DiffRemoved, From: "old", To: nil},
+				{Path: "c", Type: DiffModified, From: "v1", To: "v2"},
+				{Path: "d", Type: DiffOrderChanged, From: nil, To: nil},
+			},
+		},
+	}
+
+	got := buildPrompt(groups)
+	for _, label := range []string{"[ADDED]", "[REMOVED]", "[MODIFIED]", "[ORDER_CHANGED]"} {
+		if !strings.Contains(got, label) {
+			t.Errorf("buildPrompt missing %s label, got: %s", label, got)
+		}
+	}
+}
+
+func TestBuildPrompt_MultipleFiles(t *testing.T) {
+	groups := []DiffGroup{
+		{
+			FilePath: "file1.yaml",
+			Diffs:    []Difference{{Path: "a", Type: DiffAdded, To: "x"}},
+		},
+		{
+			FilePath: "file2.yaml",
+			Diffs:    []Difference{{Path: "b", Type: DiffRemoved, From: "y"}},
+		},
+	}
+
+	got := buildPrompt(groups)
+	if !strings.Contains(got, "File: file1.yaml") || !strings.Contains(got, "File: file2.yaml") {
+		t.Errorf("buildPrompt missing multiple file headers, got: %s", got)
+	}
+}
+
+func TestBuildPrompt_Truncation(t *testing.T) {
+	// Create enough diffs to exceed ~8000 chars
+	var diffs []Difference
+	for i := 0; i < 500; i++ {
+		diffs = append(diffs, Difference{
+			Path: strings.Repeat("very.long.path.segment.", 5) + "key",
+			Type: DiffModified,
+			From: strings.Repeat("old-value-", 10),
+			To:   strings.Repeat("new-value-", 10),
+		})
+	}
+
+	groups := []DiffGroup{
+		{FilePath: "file1.yaml", Diffs: diffs[:250]},
+		{FilePath: "file2.yaml", Diffs: diffs[250:]},
+	}
+
+	got := buildPrompt(groups)
+	if !strings.Contains(got, "truncated") {
+		t.Errorf("buildPrompt should truncate large input, got length: %d", len(got))
+	}
+}
+
+// --- systemPrompt tests ---
+
+func TestSystemPrompt_NotEmpty(t *testing.T) {
+	got := systemPrompt()
+	if got == "" {
+		t.Error("systemPrompt() should not be empty")
+	}
+	if !strings.Contains(got, "YAML") {
+		t.Error("systemPrompt() should mention YAML")
+	}
+}
+
+// --- formatSummaryOutput tests ---
+
+func TestFormatSummaryOutput_NoColor(t *testing.T) {
+	opts := &FormatOptions{Color: false}
+	got := formatSummaryOutput("Test summary text.", opts)
+
+	if !strings.Contains(got, "AI Summary:") {
+		t.Errorf("formatSummaryOutput missing header, got: %s", got)
+	}
+	if !strings.Contains(got, "Test summary text.") {
+		t.Errorf("formatSummaryOutput missing body, got: %s", got)
+	}
+	if !strings.HasPrefix(got, "\n") {
+		t.Errorf("formatSummaryOutput should start with blank line, got: %s", got)
+	}
+}
+
+func TestFormatSummaryOutput_WithColor(t *testing.T) {
+	opts := &FormatOptions{Color: true}
+	got := formatSummaryOutput("Test summary.", opts)
+
+	if !strings.Contains(got, colorCyan) {
+		t.Errorf("formatSummaryOutput with color should use cyan, got: %s", got)
+	}
+	if !strings.Contains(got, styleBold) {
+		t.Errorf("formatSummaryOutput with color should use bold, got: %s", got)
+	}
+	if !strings.Contains(got, colorReset) {
+		t.Errorf("formatSummaryOutput with color should reset, got: %s", got)
+	}
+}
+
+// --- Summarizer tests ---
+
+func TestNewSummarizer_DefaultModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	s := NewSummarizer("")
+	if s.model != defaultModel {
+		t.Errorf("NewSummarizer(\"\").model = %q, want %q", s.model, defaultModel)
+	}
+}
+
+func TestNewSummarizer_CustomModel(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	s := NewSummarizer("claude-sonnet-4-20250514")
+	if s.model != "claude-sonnet-4-20250514" {
+		t.Errorf("NewSummarizer custom model = %q, want %q", s.model, "claude-sonnet-4-20250514")
+	}
+}
+
+func TestSummarize_Success(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 200,
+		body:       `{"content":[{"type":"text","text":"The replicas were increased from 3 to 5."}]}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{
+			FilePath: "deploy.yaml",
+			Diffs: []Difference{
+				{Path: "spec.replicas", Type: DiffModified, From: 3, To: 5},
+			},
+		},
+	}
+
+	summary, err := s.Summarize(context.Background(), groups)
+	if err != nil {
+		t.Fatalf("Summarize() error = %v", err)
+	}
+	if summary != "The replicas were increased from 3 to 5." {
+		t.Errorf("Summarize() = %q, want expected summary", summary)
+	}
+
+	// Verify request headers
+	if mock.lastReq.Header.Get("x-api-key") != "test-key" {
+		t.Error("request missing x-api-key header")
+	}
+	if mock.lastReq.Header.Get("anthropic-version") != anthropicVersion {
+		t.Error("request missing anthropic-version header")
+	}
+	if mock.lastReq.Header.Get("Content-Type") != "application/json" {
+		t.Error("request missing Content-Type header")
+	}
+}
+
+func TestSummarize_NetworkError(t *testing.T) {
+	mock := &mockHTTPDoer{
+		err: io.ErrUnexpectedEOF,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for network failure")
+	}
+}
+
+func TestSummarize_Auth401(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 401,
+		body:       `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for 401")
+	}
+	if !strings.Contains(err.Error(), "invalid API key") {
+		t.Errorf("error should mention 'invalid API key', got: %v", err)
+	}
+}
+
+func TestSummarize_RateLimit429(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 429,
+		body:       `{"type":"error","error":{"type":"rate_limit_error","message":"rate limited"}}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error should mention 'rate limited', got: %v", err)
+	}
+}
+
+func TestSummarize_ServerError500(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 500,
+		body:       `{"type":"error","error":{"type":"api_error","message":"internal error"}}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for 500")
+	}
+	if !strings.Contains(err.Error(), "server error") {
+		t.Errorf("error should mention 'server error', got: %v", err)
+	}
+}
+
+func TestSummarize_MalformedResponse(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 200,
+		body:       `{"content":[]}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for malformed response")
+	}
+	if !strings.Contains(err.Error(), "unexpected response format") {
+		t.Errorf("error should mention 'unexpected response format', got: %v", err)
+	}
+}
+
+func TestSummarize_EmptyTextBlock(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 200,
+		body:       `{"content":[{"type":"text","text":""}]}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for empty text")
+	}
+}
+
+func TestSummarize_Timeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+
+	mock := &mockHTTPDoer{
+		statusCode: 200,
+		body:       `{"content":[{"type":"text","text":"ok"}]}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(ctx, groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for cancelled context")
+	}
+}
+
+func TestSummarize_APIErrorInBody(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 400,
+		body:       `{"type":"error","error":{"type":"invalid_request_error","message":"model not found"}}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error for 400")
+	}
+	if !strings.Contains(err.Error(), "model not found") {
+		t.Errorf("error should contain API error message, got: %v", err)
+	}
+}
+
+func TestSummarize_NoTextContentBlock(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 200,
+		body:       `{"content":[{"type":"tool_use","text":"irrelevant"}]}`,
+	}
+	s := NewSummarizerWithClient("test-model", "test-key", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err == nil {
+		t.Fatal("Summarize() expected error when no text block found")
+	}
+}
+
+func TestSummarize_APIKeyNotInError(t *testing.T) {
+	mock := &mockHTTPDoer{
+		statusCode: 401,
+		body:       `{"type":"error","error":{"type":"authentication_error","message":"invalid"}}`,
+	}
+	s := NewSummarizerWithClient("test-model", "secret-api-key-12345", mock)
+
+	groups := []DiffGroup{
+		{FilePath: "f.yaml", Diffs: []Difference{{Path: "a", Type: DiffAdded, To: "v"}}},
+	}
+
+	_, err := s.Summarize(context.Background(), groups)
+	if err != nil && strings.Contains(err.Error(), "secret-api-key-12345") {
+		t.Error("API key should never appear in error messages")
+	}
+}


### PR DESCRIPTION
## What

Add optional `--summary` / `-S` flag that generates AI-powered natural language summaries of YAML differences using the Anthropic Messages API.

## Why

Reading raw structural diffs can be time-consuming. A concise natural language summary helps users quickly understand the impact of YAML changes without parsing diff output manually.

## How

- **New file `summarizer.go`**: Self-contained module handling prompt construction, Anthropic API calls (via `net/http` stdlib), response parsing, and error handling. No new external dependencies.
- **CLI extension**: `--summary` / `-S` boolean flag and `--summary-model` string flag registered in `initFlags`. Validation requires `ANTHROPIC_API_KEY` env var when `--summary` is set (exit 255 if missing).
- **Integration**: Summary appended after standard diff output in both single-file and directory modes. Works with all 6 output formats (detailed, compact, brief, github, gitlab, gitea).
- **Brief special case**: When `--summary` + `--brief`, AI summary replaces brief output (both serve similar purpose). Falls back to brief on API failure.
- **Error handling**: Graceful degradation — API failures produce a warning to stderr without affecting exit codes or suppressing diff output. 30-second timeout enforced via context.
- **Testability**: HTTP client abstracted behind `httpDoer` interface; `SummaryAPIURL` field on `RunConfig` allows test servers. All API interactions tested via `httptest.NewServer`.
- **README**: Added AI Summary usage section with examples, flags to the reference table, and feature highlight in the features list.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `doc:`, `chore:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

- 2082 lines added across 8 files (304 impl + 1178 tests + 600 integration tests + README)
- Default model is `claude-haiku-4-5-20251001` (fast, cost-effective for short summaries)
- Prompt truncation at file-group boundaries keeps input under ~8000 chars
- API key is never logged, printed, or included in error messages