### PR TITLE
doc: update README with --ignore-api-version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Structural diff for YAML files. Understands YAML semantics and detects Kubernete
 ## Features
 
 - **Minimal dependencies** — single runtime dependency ([yaml.v3](https://github.com/yaml/go-yaml)); pure Go stdlib otherwise. Small attack surface, fast by design ([benchmarks](#performance))
-- **Kubernetes-aware** — auto-detects and matches resources by apiVersion, kind, and metadata
+- **Kubernetes-aware** — auto-detects and matches resources by apiVersion, kind, and metadata; optional apiVersion-agnostic matching for API migrations
 - **Rename detection** — identifies renamed resources instead of showing remove + add
 - **6 output formats** — detailed, compact, brief, GitHub, GitLab, Gitea
 - **Path filtering** — include/exclude paths with exact match or regex
@@ -89,11 +89,16 @@ diffyml [flags] <from> <to>
 
 Kubernetes resources are automatically detected and matched by `apiVersion`, `kind`, and `metadata.name`. Renames are tracked as moves, not as remove + add.
 
+Use `--ignore-api-version` to drop `apiVersion` from the matching key — resources are paired by `kind` + `name` only, so an API migration (e.g. `apps/v1beta1` → `apps/v1`) shows field-level diffs instead of a remove + add. Use `--detect-kubernetes=false` to disable K8s-aware matching entirely and compare documents by position.
+
 ```bash
 # Compare two Kubernetes manifests
 diffyml manifests-v1.yaml manifests-v2.yaml
 
-# Disable Kubernetes detection
+# Ignore apiVersion when matching — useful for API migrations (e.g. apps/v1beta1 → apps/v1)
+diffyml --ignore-api-version manifests-v1.yaml manifests-v2.yaml
+
+# Disable Kubernetes detection — compare documents by position
 diffyml --detect-kubernetes=false file1.yaml file2.yaml
 ```
 
@@ -177,6 +182,7 @@ The summary is appended after the standard diff output. If the API call fails, a
 | `-v, --ignore-value-changes` | Show only structural changes, exclude value changes |
 | `--detect-kubernetes` | Detect and match Kubernetes resources (default `true`) |
 | `--detect-renames` | Detect renamed resources (default `true`) |
+| `--ignore-api-version` | Ignore `apiVersion` when matching Kubernetes resources |
 | `-x, --no-cert-inspection` | Disable x509 certificate inspection |
 | `--swap` | Swap from/to files |
 


### PR DESCRIPTION
## What

Document the `--ignore-api-version` flag in README.

## Why

The flag was added in #25 but the README was not updated. Users need to discover and understand the feature.

## How

- Updated the Features list to mention apiVersion-agnostic matching
- Added usage example in the Kubernetes Support section
- Added a paragraph explaining the difference between `--ignore-api-version` and `--detect-kubernetes=false`
- Added the flag to the All Flags reference table

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Documentation-only change. No code modifications.