### PR TITLE
fix: suppress relative-path warning for /dev/ paths

### DIFF
--- a/pkg/diffyml/cli/cli.go
+++ b/pkg/diffyml/cli/cli.go
@@ -657,6 +657,11 @@ func normalizeFilePath(path string, stderr io.Writer) string {
 		return ""
 	}
 
+	// /dev/ paths (process substitution, stdin) are inherently non-relative; skip warning
+	if strings.HasPrefix(path, "/dev/") {
+		return path
+	}
+
 	if filepath.IsAbs(path) {
 		cwd, err := os.Getwd()
 		if err == nil {

--- a/pkg/diffyml/cli/cli_normalize_test.go
+++ b/pkg/diffyml/cli/cli_normalize_test.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeFilePath_Empty(t *testing.T) {
+	got := normalizeFilePath("", nil)
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestNormalizeFilePath_DevPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"dev_fd", "/dev/fd/12"},
+		{"dev_stdin", "/dev/stdin"},
+		{"dev_null", "/dev/null"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			got := normalizeFilePath(tt.path, &stderr)
+			if got != tt.path {
+				t.Errorf("expected %q, got %q", tt.path, got)
+			}
+			if stderr.Len() > 0 {
+				t.Errorf("expected no warning for %s, got %q", tt.path, stderr.String())
+			}
+		})
+	}
+}
+
+func TestNormalizeFilePath_RelativePath(t *testing.T) {
+	got := normalizeFilePath("./some/file.yaml", nil)
+	if got != "some/file.yaml" {
+		t.Errorf("expected 'some/file.yaml', got %q", got)
+	}
+}
+
+func TestNormalizeFilePath_AlreadyRelative(t *testing.T) {
+	got := normalizeFilePath("some/file.yaml", nil)
+	if got != "some/file.yaml" {
+		t.Errorf("expected 'some/file.yaml', got %q", got)
+	}
+}
+
+func TestNormalizeFilePath_AbsoluteInCwd(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	absPath := filepath.Join(cwd, "testfile.yaml")
+
+	var stderr bytes.Buffer
+	got := normalizeFilePath(absPath, &stderr)
+	if got != "testfile.yaml" {
+		t.Errorf("expected 'testfile.yaml', got %q", got)
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("expected no warning, got %q", stderr.String())
+	}
+}
+
+func TestNormalizeFilePath_AbsoluteOutsideCwd(t *testing.T) {
+	var stderr bytes.Buffer
+	got := normalizeFilePath("/nonexistent/path/file.yaml", &stderr)
+	if got != "/nonexistent/path/file.yaml" {
+		t.Errorf("expected absolute path back, got %q", got)
+	}
+	if !strings.Contains(stderr.String(), "Warning") {
+		t.Errorf("expected warning, got %q", stderr.String())
+	}
+}
+
+func TestNormalizeFilePath_AbsoluteOutsideCwd_NilStderr(t *testing.T) {
+	got := normalizeFilePath("/nonexistent/path/file.yaml", nil)
+	if got != "/nonexistent/path/file.yaml" {
+		t.Errorf("expected absolute path back, got %q", got)
+	}
+}


### PR DESCRIPTION
## What

Suppress the noisy "could not determine relative path" warning when using process substitution (`<(...)`) or stdin (`/dev/fd/N`).

## Why

`/dev/fd/N` paths from process substitution can never be made relative to cwd. The warning adds no value and clutters stderr output.

## How

Early return in `normalizeFilePath` for paths starting with `/dev/`, placed before the `os.Getwd()`/`filepath.Rel()` calls to also avoid unnecessary syscalls.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Added `cli_normalize_test.go` with full branch coverage for `normalizeFilePath` (empty, /dev/ paths, relative, absolute in/outside cwd, nil stderr).