### PR TITLE
test: enable race detector in test and e2e targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           go-version: "1.26.1"
 
       - name: Run tests
-        run: go test ./...
+        run: go test -race ./...
 
   fuzz:
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,10 @@ golangci-lint:
 security: govulncheck golangci-lint
 
 test:
-	go test ./...
+	go test -race ./...
 
 e2e: build
-	go test -v -timeout 120s ./test/e2e/
+	go test -race -v -timeout 120s ./test/e2e/
 
 fmt:
 	gofmt -l -w .


### PR DESCRIPTION
## Summary
- Add `-race` flag to `go test` in Makefile (`test`, `e2e` targets) and CI test job
- Fuzz and coverage targets left unchanged (race detector conflicts with those modes)
- Standard Go practice for detecting data races early; prerequisite for any future concurrency work

## Test plan
- [x] `make test` passes locally with `-race`
- [x] CI test job passes with `-race`