### PR TITLE
chore: add errorlint, depguard, and gofumpt linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,9 @@ version: "2"
 
 linters:
   enable:
+    - depguard
     - errcheck
+    - errorlint
     - gocritic
     - gosec
     - govet
@@ -10,6 +12,16 @@ linters:
     - misspell
     - staticcheck
   settings:
+    depguard:
+      rules:
+        main:
+          list-mode: strict
+          files:
+            - "!$test"
+          allow:
+            - $gostd
+            - github.com/szhekpisov/diffyml
+            - gopkg.in/yaml.v3
     errcheck:
       # Terminal output and cleanup — errors are intentionally ignored
       exclude-functions:
@@ -37,3 +49,7 @@ linters:
       - path: _test\.go
         linters:
           - gosec
+
+formatters:
+  enable:
+    - gofumpt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: local
     hooks:
       - id: go-fmt
-        name: gofmt
+        name: gofumpt
         entry: make fmt
         language: system
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ e2e: build
 	go test -race -v -timeout 120s ./test/e2e/
 
 fmt:
-	gofmt -l -w .
+	go run mvdan.cc/gofumpt@latest -l -w .
 
 lint: golangci-lint
 

--- a/pkg/diffyml/cli/cli_exitcode_test.go
+++ b/pkg/diffyml/cli/cli_exitcode_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -91,7 +92,7 @@ func TestExitResult_WithError(t *testing.T) {
 	if result.Code != ExitCodeError {
 		t.Errorf("expected code %d, got %d", ExitCodeError, result.Code)
 	}
-	if result.Err != err {
+	if !errors.Is(result.Err, err) {
 		t.Errorf("expected error %v, got %v", err, result.Err)
 	}
 	if result.IsSuccess() {

--- a/pkg/diffyml/cli/coverage_gaps_test.go
+++ b/pkg/diffyml/cli/coverage_gaps_test.go
@@ -99,7 +99,7 @@ func TestRunDirectory_RealFilesystem_OnlyFromAndOnlyTo(t *testing.T) {
 
 func writeTestFile(t *testing.T, path string, content string) {
 	t.Helper()
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("failed to write %s: %v", path, err)
 	}
 }

--- a/pkg/diffyml/cli/directory.go
+++ b/pkg/diffyml/cli/directory.go
@@ -76,7 +76,8 @@ func compareAndFilterPair(from, to []byte, compareOpts *diffyml.Options, filterO
 // emitDirectorySummary generates and emits AI summaries for directory mode.
 // Handles both structured (aggregated) and non-structured (per-file) formatters.
 func emitDirectorySummary(cfg *CLIConfig, rc *RunConfig, groups []diffyml.DiffGroup, entries []summaryEntry,
-	formatOpts *diffyml.FormatOptions, formatter diffyml.Formatter, isStructured, isBriefSummary bool) {
+	formatOpts *diffyml.FormatOptions, formatter diffyml.Formatter, isStructured, isBriefSummary bool,
+) {
 	if isStructured && len(groups) > 0 {
 		summarizer := NewSummarizer(cfg.SummaryModel)
 		if rc.SummaryAPIURL != "" {

--- a/pkg/diffyml/detailed_formatter_color_test.go
+++ b/pkg/diffyml/detailed_formatter_color_test.go
@@ -499,9 +499,11 @@ func TestDetailedFormatter_ColorEnabled_OrderChangeWasRed(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -519,9 +521,11 @@ func TestDetailedFormatter_ColorEnabled_OrderChangeNowGreen(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -539,9 +543,11 @@ func TestDetailedFormatter_ColorDisabled_PlainOrderChange(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -576,9 +582,11 @@ func TestDetailedFormatter_Integration_AllDiffTypesColored(t *testing.T) {
 		// Modified: scalar value change
 		{Path: "config.timeout", Type: DiffModified, From: "30", To: "60"},
 		// Order changed (exercises colored was/now)
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b", "c"},
-			To:   []any{"c", "b", "a"}},
+			To:   []any{"c", "b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -634,9 +642,11 @@ func TestDetailedFormatter_Integration_AllDiffTypesUncolored(t *testing.T) {
 		{Path: "config.oldKey", Type: DiffRemoved, From: "deprecated"},
 		{Path: "config.port", Type: DiffModified, From: 8080, To: "8080"},
 		{Path: "config.timeout", Type: DiffModified, From: "30", To: "60"},
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b", "c"},
-			To:   []any{"c", "b", "a"}},
+			To:   []any{"c", "b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -678,9 +688,11 @@ func TestDetailedFormatter_Integration_TrueColorBoldItalicCombination(t *testing
 			return om
 		}()},
 		// Order change to exercise true color red/green on was/now
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"x", "y"},
-			To:   []any{"y", "x"}},
+			To:   []any{"y", "x"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -739,9 +751,11 @@ func TestDetailedFormatter_Integration_AutoColorModeNoTerminal(t *testing.T) {
 			return om
 		}()},
 		{Path: "config.port", Type: DiffModified, From: 8080, To: "8080"},
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)

--- a/pkg/diffyml/detailed_formatter_helpers.go
+++ b/pkg/diffyml/detailed_formatter_helpers.go
@@ -99,8 +99,10 @@ func formatTimestamp(t time.Time) string {
 // formatCount returns a human-readable count string.
 // Numbers 1-12 are spelled out as English words.
 func formatCount(n int) string {
-	words := []string{"zero", "one", "two", "three", "four", "five",
-		"six", "seven", "eight", "nine", "ten", "eleven", "twelve"}
+	words := []string{
+		"zero", "one", "two", "three", "four", "five",
+		"six", "seven", "eight", "nine", "ten", "eleven", "twelve",
+	}
 	if n >= 0 && n < len(words) {
 		return words[n]
 	}

--- a/pkg/diffyml/detailed_formatter_snapshot_test.go
+++ b/pkg/diffyml/detailed_formatter_snapshot_test.go
@@ -75,9 +75,11 @@ func TestDetailedFormatter_Snapshot_OrderChange(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -249,8 +251,10 @@ func TestDetailedFormatter_Integration_NoRegressionSnapshots(t *testing.T) {
 		},
 		{
 			name: "order change",
-			diffs: []Difference{{Path: "items", Type: DiffOrderChanged,
-				From: []any{"a", "b"}, To: []any{"b", "a"}}},
+			diffs: []Difference{{
+				Path: "items", Type: DiffOrderChanged,
+				From: []any{"a", "b"}, To: []any{"b", "a"},
+			}},
 			expected: "items\n  ⇆ order changed\n    - a, b\n    + b, a\n\n",
 		},
 		{
@@ -301,9 +305,11 @@ func TestDetailedFormatter_Snapshot_FullComparison(t *testing.T) {
 		// Type change
 		{Path: "config.port", Type: DiffModified, From: 8080, To: "8080"},
 		// Order change
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)

--- a/pkg/diffyml/detailed_formatter_test.go
+++ b/pkg/diffyml/detailed_formatter_test.go
@@ -837,9 +837,11 @@ func TestDetailedFormatter_OrderChangedWithValues(t *testing.T) {
 	opts := DefaultFormatOptions()
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"x", "y", "z"},
-			To:   []any{"z", "y", "x"}},
+			To:   []any{"z", "y", "x"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -1006,9 +1008,11 @@ func TestDetailedFormatter_TrailingSeparator_OrderChange(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -1067,9 +1071,11 @@ func TestDetailedFormatter_OrderChange_CommaSeparated(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b", "c"},
-			To:   []any{"c", "a", "b"}},
+			To:   []any{"c", "a", "b"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -1087,9 +1093,11 @@ func TestDetailedFormatter_OrderChange_SingleItem(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a"},
-			To:   []any{"a"}},
+			To:   []any{"a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -1107,9 +1115,11 @@ func TestDetailedFormatter_OrderChange_NonStringItems(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "nums", Type: DiffOrderChanged,
+		{
+			Path: "nums", Type: DiffOrderChanged,
 			From: []any{1, 2, 3},
-			To:   []any{3, 1, 2}},
+			To:   []any{3, 1, 2},
+		},
 	}
 
 	output := f.Format(diffs, opts)
@@ -1127,9 +1137,11 @@ func TestDetailedFormatter_OrderChange_Snapshot(t *testing.T) {
 	opts.OmitHeader = true
 
 	diffs := []Difference{
-		{Path: "items", Type: DiffOrderChanged,
+		{
+			Path: "items", Type: DiffOrderChanged,
 			From: []any{"a", "b"},
-			To:   []any{"b", "a"}},
+			To:   []any{"b", "a"},
+		},
 	}
 
 	output := f.Format(diffs, opts)

--- a/pkg/diffyml/fuzz_test.go
+++ b/pkg/diffyml/fuzz_test.go
@@ -1,6 +1,7 @@
 package diffyml
 
 import (
+	"errors"
 	"io"
 	"testing"
 )
@@ -127,7 +128,7 @@ func FuzzDocumentParser(f *testing.F) {
 		// Cap iterations to prevent DoS on inputs with many "---" separators.
 		for i := 0; i < 10_000; i++ {
 			_, err := p.Next()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 		}

--- a/pkg/diffyml/ordered_map.go
+++ b/pkg/diffyml/ordered_map.go
@@ -8,6 +8,7 @@ package diffyml
 
 import (
 	"bytes"
+	"errors"
 	"io"
 
 	"gopkg.in/yaml.v3"
@@ -36,7 +37,7 @@ func ParseWithOrder(content []byte) ([]any, error) {
 	for {
 		var node yaml.Node
 		err := decoder.Decode(&node)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/pkg/diffyml/parser.go
+++ b/pkg/diffyml/parser.go
@@ -7,6 +7,7 @@ package diffyml
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 
@@ -40,7 +41,7 @@ func (p *DocumentParser) Next() (any, error) {
 
 	var doc any
 	err := p.decoder.Decode(&doc)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		p.done = true
 		// If we haven't parsed any documents, return one nil document
 		if p.docNum == 0 {
@@ -79,7 +80,7 @@ func parseNodes(content []byte) ([]*yaml.Node, error) {
 	for {
 		var node yaml.Node
 		err := decoder.Decode(&node)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -115,7 +116,7 @@ func (p *NodeDocumentParser) Next() (*yaml.Node, error) {
 
 	var node yaml.Node
 	err := p.decoder.Decode(&node)
-	if err == io.EOF {
+	if errors.Is(err, io.EOF) {
 		p.done = true
 		return nil, io.EOF
 	}
@@ -162,7 +163,8 @@ func (e *ParseError) Unwrap() error {
 func wrapParseError(err error) error {
 	// yaml.v3 includes line info in the error message
 	// Try to extract it if possible
-	if typeErr, ok := err.(*yaml.TypeError); ok {
+	var typeErr *yaml.TypeError
+	if errors.As(err, &typeErr) {
 		return &ParseError{
 			Message: typeErr.Error(),
 			Err:     err,

--- a/pkg/diffyml/parser_coverage_test.go
+++ b/pkg/diffyml/parser_coverage_test.go
@@ -14,7 +14,7 @@ func drainDocumentParser(t *testing.T, p *DocumentParser, wantErr bool) (docs []
 	t.Helper()
 	for {
 		doc, err := p.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -33,7 +33,7 @@ func drainNodeDocumentParser(t *testing.T, p *NodeDocumentParser, wantErr bool) 
 	t.Helper()
 	for {
 		node, err := p.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
@@ -116,7 +116,7 @@ func TestDocumentParser(t *testing.T) {
 		drainDocumentParser(t, p, false)
 		// Subsequent call should still be EOF
 		_, err := p.Next()
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			t.Errorf("expected io.EOF on repeated call, got %v", err)
 		}
 	})
@@ -188,7 +188,7 @@ func TestNodeDocumentParser(t *testing.T) {
 		p := NewNodeDocumentParser([]byte("x: 1\n"))
 		drainNodeDocumentParser(t, p, false)
 		_, err := p.Next()
-		if err != io.EOF {
+		if !errors.Is(err, io.EOF) {
 			t.Errorf("expected io.EOF on repeated call, got %v", err)
 		}
 	})
@@ -280,11 +280,11 @@ func TestWrapParseError(t *testing.T) {
 	t.Run("yaml TypeError", func(t *testing.T) {
 		typeErr := &yaml.TypeError{Errors: []string{"test error"}}
 		got := wrapParseError(typeErr)
-		pe, ok := got.(*ParseError)
-		if !ok {
+		var pe *ParseError
+		if !errors.As(got, &pe) {
 			t.Fatalf("expected *ParseError, got %T", got)
 		}
-		if pe.Err != typeErr {
+		if !errors.Is(pe.Err, typeErr) {
 			t.Error("expected Err to wrap original TypeError")
 		}
 	})
@@ -292,7 +292,7 @@ func TestWrapParseError(t *testing.T) {
 	t.Run("other error", func(t *testing.T) {
 		orig := errors.New("some other error")
 		got := wrapParseError(orig)
-		if got != orig {
+		if !errors.Is(got, orig) {
 			t.Errorf("expected original error returned unchanged, got %v", got)
 		}
 	})

--- a/pkg/diffyml/parser_test.go
+++ b/pkg/diffyml/parser_test.go
@@ -1,6 +1,7 @@
 package diffyml
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -263,7 +264,8 @@ valid: content
 	}
 
 	// Check if error can be converted to ParseError
-	if pe, ok := err.(*ParseError); ok {
+	var pe *ParseError
+	if errors.As(err, &pe) {
 		if pe.Line == 0 {
 			t.Error("expected non-zero line number in ParseError")
 		}

--- a/pkg/diffyml/remote_test.go
+++ b/pkg/diffyml/remote_test.go
@@ -212,10 +212,10 @@ func TestValidateFileExists_IsDirectory(t *testing.T) {
 func TestValidateFileExists_PermissionError(t *testing.T) {
 	dir := t.TempDir()
 	nested := dir + "/noperm"
-	if err := os.Mkdir(nested, 0000); err != nil {
+	if err := os.Mkdir(nested, 0o000); err != nil {
 		t.Fatalf("failed to create dir: %v", err)
 	}
-	defer func() { _ = os.Chmod(nested, 0700) }()
+	defer func() { _ = os.Chmod(nested, 0o700) }()
 
 	err := ValidateFileExists(nested + "/file.yaml")
 	if err == nil {
@@ -229,10 +229,10 @@ func TestValidateFileExists_PermissionError(t *testing.T) {
 func TestLoadContent_UnreadableFile(t *testing.T) {
 	dir := t.TempDir()
 	path := dir + "/unreadable.yaml"
-	if err := os.WriteFile(path, []byte("data"), 0000); err != nil {
+	if err := os.WriteFile(path, []byte("data"), 0o000); err != nil {
 		t.Fatalf("failed to create file: %v", err)
 	}
-	defer func() { _ = os.Chmod(path, 0600) }()
+	defer func() { _ = os.Chmod(path, 0o600) }()
 
 	_, err := LoadContent(path)
 	if err == nil {
@@ -290,5 +290,5 @@ func TestFetchURL_HTTP300Rejected(t *testing.T) {
 
 // writeTestFile is a helper to create test files.
 func writeTestFile(path string, content []byte) error {
-	return os.WriteFile(path, content, 0600)
+	return os.WriteFile(path, content, 0o600)
 }

--- a/test/e2e/kubectl_diff_test.go
+++ b/test/e2e/kubectl_diff_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"os"
@@ -117,7 +118,7 @@ func setupKindCluster(t *testing.T) (diffymlBin string, baseEnv []string) {
 	if err != nil {
 		t.Fatalf("failed to get kubeconfig: %v", err)
 	}
-	if err := os.WriteFile(kubeconfigPath, kcOut, 0600); err != nil {
+	if err := os.WriteFile(kubeconfigPath, kcOut, 0o600); err != nil {
 		t.Fatalf("failed to write kubeconfig: %v", err)
 	}
 
@@ -159,7 +160,8 @@ func TestKubectlDiffWithDiffyml(t *testing.T) {
 
 		err := diffCmd.Run()
 		if err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
 				exitCode = exitErr.ExitCode()
 			} else {
 				t.Fatalf("kubectl diff failed unexpectedly: %v\nstderr: %s", err, errBuf.String())

--- a/test/property/build_system_test.go
+++ b/test/property/build_system_test.go
@@ -34,7 +34,7 @@ func TestProperty2_BuildSystemSuccess(t *testing.T) {
 		t.Fatal("Binary is not a regular file")
 	}
 
-	if info.Mode()&0111 == 0 {
+	if info.Mode()&0o111 == 0 {
 		t.Fatal("Binary is not executable")
 	}
 }
@@ -70,7 +70,7 @@ func TestProperty2_BuildSystemSuccess_WithCleanEnvironment(t *testing.T) {
 		t.Fatalf("Binary not found: %v", err)
 	}
 
-	if !info.Mode().IsRegular() || info.Mode()&0111 == 0 {
+	if !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
 		t.Fatal("Binary is not a regular executable file")
 	}
 }
@@ -98,7 +98,7 @@ func TestProperty2_BuildSystemSuccess_WithLdflags(t *testing.T) {
 		t.Fatalf("Binary not found: %v", err)
 	}
 
-	if !info.Mode().IsRegular() || info.Mode()&0111 == 0 {
+	if !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
 		t.Fatal("Binary is not a regular executable file")
 	}
 
@@ -158,7 +158,7 @@ func TestProperty4_SingleBinaryOutput(t *testing.T) {
 		t.Fatal("Output is not a regular file")
 	}
 
-	if info.Mode()&0111 == 0 {
+	if info.Mode()&0o111 == 0 {
 		t.Fatal("Output is not executable")
 	}
 
@@ -195,7 +195,7 @@ func TestProperty4_SingleBinaryOutput_WithDefaultName(t *testing.T) {
 		t.Fatalf("Default binary not found: %v", err)
 	}
 
-	if !info.Mode().IsRegular() || info.Mode()&0111 == 0 {
+	if !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
 		t.Fatal("Binary is not a regular executable file")
 	}
 }
@@ -376,7 +376,7 @@ func TestProperty5_DependencyIntegrity_BuildWithVerify(t *testing.T) {
 		t.Fatalf("Binary not found: %v", err)
 	}
 
-	if !info.Mode().IsRegular() || info.Mode()&0111 == 0 {
+	if !info.Mode().IsRegular() || info.Mode()&0o111 == 0 {
 		t.Fatal("Binary is not a regular executable file")
 	}
 }

--- a/test/property/dependency_licenses_test.go
+++ b/test/property/dependency_licenses_test.go
@@ -24,7 +24,6 @@ func TestProperty10_OpenSourceDependencies(t *testing.T) {
 	// Run go-licenses check to verify all dependencies have acceptable licenses
 	cmd := exec.Command(goLicensesPath, "check", "./...")
 	output, err := cmd.CombinedOutput()
-
 	if err != nil {
 		// Check if the error is due to go-licenses not being installed
 		if strings.Contains(string(output), "not found") ||
@@ -57,7 +56,6 @@ func TestProperty10_OpenSourceDependencies_Report(t *testing.T) {
 	// Run go-licenses report to get license information
 	cmd := exec.Command(goLicensesPath, "report", "./...")
 	output, err := cmd.CombinedOutput()
-
 	if err != nil {
 		if strings.Contains(string(output), "not found") ||
 			strings.Contains(err.Error(), "not found") ||
@@ -134,7 +132,6 @@ func TestProperty10_OpenSourceDependencies_NoProprietaryLicenses(t *testing.T) {
 	// Run go-licenses report
 	cmd := exec.Command(goLicensesPath, "report", "./...")
 	output, err := cmd.CombinedOutput()
-
 	if err != nil {
 		if strings.Contains(string(output), "not found") ||
 			strings.Contains(err.Error(), "not found") ||

--- a/test/property/repository_structure_test.go
+++ b/test/property/repository_structure_test.go
@@ -179,7 +179,6 @@ func TestProperty17_LibraryCodeOrganization_WithPackageValidation(t *testing.T) 
 
 		return nil
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to walk pkg/ directory: %v", err)
 	}
@@ -345,7 +344,7 @@ func TestProperty18_NoPrebuiltBinaries(t *testing.T) {
 			return nil
 		}
 
-		if info.Mode()&0111 != 0 {
+		if info.Mode()&0o111 != 0 {
 			if strings.HasSuffix(path, ".sh") ||
 				strings.HasSuffix(path, ".bash") ||
 				strings.HasSuffix(path, ".py") ||
@@ -358,7 +357,6 @@ func TestProperty18_NoPrebuiltBinaries(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to walk repository: %v", err)
 	}

--- a/test/property/test_system_test.go
+++ b/test/property/test_system_test.go
@@ -20,7 +20,6 @@ func TestProperty6_TestExecutionSuccess(t *testing.T) {
 	// Run go test for just the pkg/diffyml package (faster than ./...)
 	cmd := exec.Command("go", "test", "./pkg/diffyml/...")
 	output, err := cmd.CombinedOutput()
-
 	// Test execution must succeed
 	if err != nil {
 		t.Fatalf("go test failed: %v\nOutput: %s", err, string(output))
@@ -56,7 +55,6 @@ func TestProperty6_TestExecutionSuccess_PackageDiscovery(t *testing.T) {
 	// Run go test for the specific package
 	cmd := exec.Command("go", "test", "./pkg/diffyml/...")
 	output, err := cmd.CombinedOutput()
-
 	if err != nil {
 		t.Fatalf("go test failed for pkg/diffyml: %v\nOutput: %s", err, string(output))
 	}
@@ -82,7 +80,6 @@ func TestProperty6_TestExecutionSuccess_ListTests(t *testing.T) {
 	// Run go test -list to list all tests
 	cmd := exec.Command("go", "test", "-list", ".*", "./pkg/diffyml/...")
 	output, err := cmd.CombinedOutput()
-
 	if err != nil {
 		t.Fatalf("go test -list failed: %v\nOutput: %s", err, string(output))
 	}
@@ -142,7 +139,6 @@ func TestProperty7_TestFixturesPresence(t *testing.T) {
 		}
 		return nil
 	})
-
 	if err != nil {
 		t.Fatalf("Error walking testdata: %v", err)
 	}

--- a/test/property/version_test.go
+++ b/test/property/version_test.go
@@ -206,7 +206,6 @@ func TestProperty23_VersionFlagExitsWithoutProcessing(t *testing.T) {
 	// Run with --version and other arguments that would normally cause errors
 	cmd := exec.Command("./diffyml_test_exit", "--version", "invalid_file.yaml", "another_invalid.yaml")
 	output, err := cmd.CombinedOutput()
-
 	// Should exit successfully (exit code 0) despite invalid arguments
 	if err != nil {
 		t.Fatalf("--version with extra args failed: %v", err)


### PR DESCRIPTION
## Summary
- Enable `errorlint` linter — enforces `errors.Is`/`errors.As` over direct error comparison and type assertion. Fixes all 15 violations across 7 files.
- Enable `depguard` linter — strict allow-list (`$gostd` + own packages + `gopkg.in/yaml.v3`) for non-test files, enforcing the single-runtime-dep guarantee.
- Enable `gofumpt` formatter — stricter `gofmt` superset. Switches `make fmt` from `gofmt` to `gofumpt` and applies formatting to 13 files.

## Test plan
- [x] `make fmt` — no further changes
- [x] `make golangci-lint` — 0 issues (all 10 linters pass)
- [x] `make test` — all tests pass with race detector