### PR TITLE
feat: add GitHub Action for structural YAML diff

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,150 @@
+name: Test Action
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-action.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-action.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Resolve latest version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(gh api repos/szhekpisov/diffyml/releases/latest --jq '.tag_name' | sed 's/^v//')
+          echo "resolved=$VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: "Test: diff detected (fail-on-diff: false)"
+        id: diff-detected
+        uses: ./
+        with:
+          from: testdata/fixtures/001-indentation/file1.yaml
+          to: testdata/fixtures/001-indentation/file2.yaml
+          version: ${{ steps.version.outputs.resolved }}
+          fail-on-diff: 'false'
+
+      - name: "Verify: has-differences is true"
+        shell: bash
+        env:
+          HAS_DIFF: ${{ steps.diff-detected.outputs.has-differences }}
+          EXIT_CODE: ${{ steps.diff-detected.outputs.exit-code }}
+        run: |
+          if [ "$HAS_DIFF" != "true" ]; then
+            echo "::error::Expected has-differences=true, got '$HAS_DIFF'"
+            exit 1
+          fi
+          if [ "$EXIT_CODE" != "1" ]; then
+            echo "::error::Expected exit-code=1, got '$EXIT_CODE'"
+            exit 1
+          fi
+
+      - name: "Test: no diff"
+        id: no-diff
+        uses: ./
+        with:
+          from: testdata/fixtures/002-self-comparison/file1.yaml
+          to: testdata/fixtures/002-self-comparison/file2.yaml
+          version: ${{ steps.version.outputs.resolved }}
+
+      - name: "Verify: no differences"
+        shell: bash
+        env:
+          HAS_DIFF: ${{ steps.no-diff.outputs.has-differences }}
+          EXIT_CODE: ${{ steps.no-diff.outputs.exit-code }}
+        run: |
+          if [ "$HAS_DIFF" != "false" ]; then
+            echo "::error::Expected has-differences=false, got '$HAS_DIFF'"
+            exit 1
+          fi
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Expected exit-code=0, got '$EXIT_CODE'"
+            exit 1
+          fi
+
+      - name: "Test: JSON output"
+        id: json-output
+        uses: ./
+        with:
+          from: testdata/fixtures/001-indentation/file1.yaml
+          to: testdata/fixtures/001-indentation/file2.yaml
+          version: ${{ steps.version.outputs.resolved }}
+          output: json
+          fail-on-diff: 'false'
+
+      - name: "Verify: JSON output is valid"
+        shell: bash
+        env:
+          DIFF: ${{ steps.json-output.outputs.diff }}
+        run: |
+          echo "$DIFF" | jq . > /dev/null
+
+      - name: "Test: diff detected (fail-on-diff: true)"
+        id: should-fail
+        uses: ./
+        continue-on-error: true
+        with:
+          from: testdata/fixtures/001-indentation/file1.yaml
+          to: testdata/fixtures/001-indentation/file2.yaml
+          version: ${{ steps.version.outputs.resolved }}
+          fail-on-diff: 'true'
+
+      - name: "Verify: step failed"
+        shell: bash
+        env:
+          OUTCOME: ${{ steps.should-fail.outcome }}
+        run: |
+          if [ "$OUTCOME" != "failure" ]; then
+            echo "::error::Expected step to fail, got outcome='$OUTCOME'"
+            exit 1
+          fi
+
+      - name: "Test: extra-args"
+        uses: ./
+        with:
+          from: testdata/fixtures/001-indentation/file1.yaml
+          to: testdata/fixtures/001-indentation/file2.yaml
+          version: ${{ steps.version.outputs.resolved }}
+          output: compact
+          fail-on-diff: 'false'
+          extra-args: '--ignore-whitespace-changes'
+
+      - name: "Test: version pinning"
+        uses: ./
+        with:
+          from: testdata/fixtures/002-self-comparison/file1.yaml
+          to: testdata/fixtures/002-self-comparison/file2.yaml
+          version: '1.5.10'
+          cache: 'false'
+
+      - name: "Test: caching disabled"
+        uses: ./
+        with:
+          from: testdata/fixtures/002-self-comparison/file1.yaml
+          to: testdata/fixtures/002-self-comparison/file2.yaml
+          version: ${{ steps.version.outputs.resolved }}
+          cache: 'false'

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -148,3 +148,11 @@ jobs:
           to: testdata/fixtures/002-self-comparison/file2.yaml
           version: ${{ steps.version.outputs.resolved }}
           cache: 'false'
+
+      - name: "Test: version latest resolution"
+        uses: ./
+        with:
+          from: testdata/fixtures/002-self-comparison/file1.yaml
+          to: testdata/fixtures/002-self-comparison/file2.yaml
+          version: 'latest'
+          cache: 'false'

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Pass any CLI flags via `extra-args`:
 
 | Output | Description |
 |--------|-------------|
-| `exit-code` | `0` (no diff), `1` (diff found), or `255` (error) |
+| `exit-code` | `0` (no diff), `1` (diff found), or `>1` (error) |
 | `has-differences` | `true`, `false`, or empty on error |
 | `diff` | Raw diff output (truncated to 1 MB) |
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,24 @@ gh attestation verify diffyml_<VERSION>_linux_amd64.tar.gz \
   --repo szhekpisov/diffyml
 ```
 
+## Quick Start
+
+```bash
+# Compare two local files
+diffyml old.yaml new.yaml
+
+# Compare local file against a remote URL
+diffyml local.yaml https://example.com/remote.yaml
+
+# Use in CI — exit code 1 when differences found
+diffyml -s deployment-old.yaml deployment-new.yaml
+
+# Use as kubectl external diff provider:
+export KUBECTL_EXTERNAL_DIFF="diffyml --omit-header --set-exit-code"
+```
+
+<img src="doc/kubectl-demo.png" alt="kubectl diff with diffyml" width="600">
+
 ### GitHub Action
 
 ```yaml
@@ -154,25 +172,7 @@ Pass any CLI flags via `extra-args`:
 |--------|-------------|
 | `exit-code` | `0` (no diff), `1` (diff found), or `255` (error) |
 | `has-differences` | `true`, `false`, or empty on error |
-| `diff` | Raw diff output |
-
-## Quick Start
-
-```bash
-# Compare two local files
-diffyml old.yaml new.yaml
-
-# Compare local file against a remote URL
-diffyml local.yaml https://example.com/remote.yaml
-
-# Use in CI — exit code 1 when differences found
-diffyml -s deployment-old.yaml deployment-new.yaml
-
-# Use as kubectl external diff provider:
-export KUBECTL_EXTERNAL_DIFF="diffyml --omit-header --set-exit-code"
-```
-
-<img src="doc/kubectl-demo.png" alt="kubectl diff with diffyml" width="600">
+| `diff` | Raw diff output (truncated to 1 MB) |
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Pass any CLI flags via `extra-args`:
 | Output | Description |
 |--------|-------------|
 | `exit-code` | `0` (no diff), `1` (diff found), or `255` (error) |
-| `has-differences` | `true` or `false` |
+| `has-differences` | `true`, `false`, or empty on error |
 | `diff` | Raw diff output |
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -107,6 +107,55 @@ gh attestation verify diffyml_<VERSION>_linux_amd64.tar.gz \
   --repo szhekpisov/diffyml
 ```
 
+### GitHub Action
+
+```yaml
+- uses: szhekpisov/diffyml@v1
+  with:
+    from: old.yaml
+    to: new.yaml
+```
+
+Detect drift without failing the workflow:
+
+```yaml
+- uses: szhekpisov/diffyml@v1
+  id: diff
+  with:
+    from: expected.yaml
+    to: actual.yaml
+    fail-on-diff: 'false'
+
+- if: steps.diff.outputs.has-differences == 'true'
+  run: echo "Configuration drift detected"
+```
+
+Pass any CLI flags via `extra-args`:
+
+```yaml
+- uses: szhekpisov/diffyml@v1
+  with:
+    from: manifests-main/
+    to: manifests-pr/
+    extra-args: '--ignore-api-version --filter spec.replicas'
+```
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `from` | *(required)* | Source YAML file or directory |
+| `to` | *(required)* | Target YAML file or directory |
+| `version` | `latest` | diffyml version (e.g. `1.5.10`) |
+| `output` | `github` | Output format (`github`, `json`, `compact`, etc.) |
+| `fail-on-diff` | `true` | Fail the step if differences found |
+| `cache` | `true` | Cache the binary across runs |
+| `extra-args` | | Additional CLI flags |
+
+| Output | Description |
+|--------|-------------|
+| `exit-code` | `0` (no diff), `1` (diff found), or `255` (error) |
+| `has-differences` | `true` or `false` |
+| `diff` | Raw diff output |
+
 ## Quick Start
 
 ```bash

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
 
 outputs:
   exit-code:
-    description: 'Exit code from diffyml (0=no diff, 1=diff found, 255=error)'
+    description: 'Exit code from diffyml (0=no diff, 1=diff found, >1=error)'
     value: ${{ steps.diff.outputs.exit-code }}
   has-differences:
     description: 'Whether differences were found (true/false, empty on error)'
@@ -64,7 +64,7 @@ runs:
     - name: Cache diffyml binary
       if: inputs.cache == 'true'
       id: cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: ~/.diffyml/bin
         key: diffyml-${{ steps.version.outputs.resolved }}-${{ runner.os }}-${{ runner.arch }}
@@ -98,9 +98,9 @@ runs:
         curl -fsSL -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
 
         if command -v sha256sum &>/dev/null; then
-          grep -F "$ARCHIVE" checksums.txt | sha256sum --check -
+          grep -F " $ARCHIVE" checksums.txt | sha256sum --check -
         else
-          grep -F "$ARCHIVE" checksums.txt | shasum -a 256 --check -
+          grep -F " $ARCHIVE" checksums.txt | shasum -a 256 --check -
         fi
 
         tar -xzf "$ARCHIVE" -C bin/ diffyml

--- a/action.yml
+++ b/action.yml
@@ -53,14 +53,13 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         VERSION="$INPUT_VERSION"
         if [ "$VERSION" = "latest" ]; then
           VERSION=$(gh api repos/szhekpisov/diffyml/releases/latest --jq '.tag_name' | sed 's/^v//')
         fi
         echo "resolved=$VERSION" >> "$GITHUB_OUTPUT"
-      # GH_TOKEN is set from github.token so `gh api` avoids anonymous rate limits.
-      # This is safe: github.token is not user-controlled.
 
     - name: Cache diffyml binary
       if: inputs.cache == 'true'
@@ -99,9 +98,9 @@ runs:
         curl -fsSL -o checksums.txt "${BASE_URL}/checksums.txt"
 
         if command -v sha256sum &>/dev/null; then
-          grep "$ARCHIVE" checksums.txt | sha256sum --check -
+          grep -F "$ARCHIVE" checksums.txt | sha256sum --check -
         else
-          grep "$ARCHIVE" checksums.txt | shasum -a 256 --check -
+          grep -F "$ARCHIVE" checksums.txt | shasum -a 256 --check -
         fi
 
         tar -xzf "$ARCHIVE" -C bin/ diffyml
@@ -156,7 +155,7 @@ runs:
           echo "$DELIM"
         } >> "$GITHUB_OUTPUT"
 
-        if [ "$EXIT_CODE" -eq 255 ]; then
+        if [ "$EXIT_CODE" -gt 1 ]; then
           exit 1
         fi
         if [ "$EXIT_CODE" -eq 1 ] && [ "$INPUT_FAIL_ON_DIFF" = "true" ]; then

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,164 @@
+name: 'diffyml'
+description: 'Structural YAML diff with Kubernetes intelligence'
+author: 'szhekpisov'
+
+branding:
+  icon: 'file-text'
+  color: 'blue'
+
+inputs:
+  from:
+    description: 'Path to the source YAML file or directory'
+    required: true
+  to:
+    description: 'Path to the target YAML file or directory'
+    required: true
+  version:
+    description: 'diffyml version to use (e.g. "1.5.10" or "latest")'
+    required: false
+    default: 'latest'
+  output:
+    description: 'Output format: compact, brief, github, gitlab, gitea, json, detailed'
+    required: false
+    default: 'github'
+  fail-on-diff:
+    description: 'Fail the action step if differences are found'
+    required: false
+    default: 'true'
+  cache:
+    description: 'Cache the downloaded binary across workflow runs'
+    required: false
+    default: 'true'
+  extra-args:
+    description: 'Additional CLI flags passed verbatim to diffyml (e.g. "--ignore-order-changes --filter spec.replicas")'
+    required: false
+    default: ''
+
+outputs:
+  exit-code:
+    description: 'Exit code from diffyml (0=no diff, 1=diff found, 255=error)'
+    value: ${{ steps.diff.outputs.exit-code }}
+  has-differences:
+    description: 'Whether differences were found (true/false)'
+    value: ${{ steps.diff.outputs.has-differences }}
+  diff:
+    description: 'Raw diff output from diffyml'
+    value: ${{ steps.diff.outputs.diff }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve version
+      id: version
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+      run: |
+        VERSION="$INPUT_VERSION"
+        if [ "$VERSION" = "latest" ]; then
+          VERSION=$(gh api repos/szhekpisov/diffyml/releases/latest --jq '.tag_name' | sed 's/^v//')
+        fi
+        echo "resolved=$VERSION" >> "$GITHUB_OUTPUT"
+      # GH_TOKEN is set from github.token so `gh api` avoids anonymous rate limits.
+      # This is safe: github.token is not user-controlled.
+
+    - name: Cache diffyml binary
+      if: inputs.cache == 'true'
+      id: cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.diffyml/bin
+        key: diffyml-${{ steps.version.outputs.resolved }}-${{ runner.os }}-${{ runner.arch }}
+
+    - name: Install diffyml
+      if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        VERSION: ${{ steps.version.outputs.resolved }}
+        RUNNER_OS: ${{ runner.os }}
+        RUNNER_ARCH: ${{ runner.arch }}
+      run: |
+        case "$RUNNER_OS" in
+          Linux)  OS="linux" ;;
+          macOS)  OS="darwin" ;;
+          *)      echo "::error::Unsupported OS: $RUNNER_OS"; exit 1 ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)    ARCH="amd64" ;;
+          ARM64)  ARCH="arm64" ;;
+          *)      echo "::error::Unsupported architecture: $RUNNER_ARCH"; exit 1 ;;
+        esac
+
+        ARCHIVE="diffyml_${VERSION}_${OS}_${ARCH}.tar.gz"
+        BASE_URL="https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}"
+
+        mkdir -p ~/.diffyml/bin
+        cd ~/.diffyml
+
+        curl -fsSL -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
+        curl -fsSL -o checksums.txt "${BASE_URL}/checksums.txt"
+
+        if command -v sha256sum &>/dev/null; then
+          grep "$ARCHIVE" checksums.txt | sha256sum --check -
+        else
+          grep "$ARCHIVE" checksums.txt | shasum -a 256 --check -
+        fi
+
+        tar -xzf "$ARCHIVE" -C bin/ diffyml
+        chmod +x bin/diffyml
+
+        rm -f "$ARCHIVE" checksums.txt
+
+    - name: Run diffyml
+      id: diff
+      shell: bash
+      env:
+        INPUT_FROM: ${{ inputs.from }}
+        INPUT_TO: ${{ inputs.to }}
+        INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
+        INPUT_FAIL_ON_DIFF: ${{ inputs.fail-on-diff }}
+      run: |
+        export PATH="$HOME/.diffyml/bin:$PATH"
+
+        ARGS=(--output "$INPUT_OUTPUT" --set-exit-code)
+
+        if [ -n "$INPUT_EXTRA_ARGS" ]; then
+          read -ra EXTRA <<< "$INPUT_EXTRA_ARGS"
+          ARGS+=("${EXTRA[@]}")
+        fi
+
+        ARGS+=("$INPUT_FROM" "$INPUT_TO")
+
+        EXIT_CODE=0
+        diffyml "${ARGS[@]}" \
+          > "$RUNNER_TEMP/diffyml_stdout.txt" \
+          2> "$RUNNER_TEMP/diffyml_stderr.txt" \
+          || EXIT_CODE=$?
+
+        cat "$RUNNER_TEMP/diffyml_stdout.txt"
+        if [ -s "$RUNNER_TEMP/diffyml_stderr.txt" ]; then
+          cat "$RUNNER_TEMP/diffyml_stderr.txt" >&2
+        fi
+
+        echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+        if [ "$EXIT_CODE" -eq 1 ]; then
+          echo "has-differences=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has-differences=false" >> "$GITHUB_OUTPUT"
+        fi
+
+        DELIM="DIFFYML_EOF_$(head -c 16 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 16)"
+        {
+          echo "diff<<$DELIM"
+          cat "$RUNNER_TEMP/diffyml_stdout.txt"
+          echo "$DELIM"
+        } >> "$GITHUB_OUTPUT"
+
+        if [ "$EXIT_CODE" -eq 255 ]; then
+          exit 1
+        fi
+        if [ "$EXIT_CODE" -eq 1 ] && [ "$INPUT_FAIL_ON_DIFF" = "true" ]; then
+          exit 1
+        fi

--- a/action.yml
+++ b/action.yml
@@ -98,9 +98,9 @@ runs:
         curl -fsSL -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
 
         if command -v sha256sum &>/dev/null; then
-          grep -F " $ARCHIVE" checksums.txt | sha256sum --check -
+          awk -v f="$ARCHIVE" '$2 == f' checksums.txt | sha256sum --check -
         else
-          grep -F " $ARCHIVE" checksums.txt | shasum -a 256 --check -
+          awk -v f="$ARCHIVE" '$2 == f' checksums.txt | shasum -a 256 --check -
         fi
 
         tar -xzf "$ARCHIVE" -C bin/ diffyml

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ outputs:
     description: 'Exit code from diffyml (0=no diff, 1=diff found, 255=error)'
     value: ${{ steps.diff.outputs.exit-code }}
   has-differences:
-    description: 'Whether differences were found (true/false)'
+    description: 'Whether differences were found (true/false, empty on error)'
     value: ${{ steps.diff.outputs.has-differences }}
   diff:
     description: 'Raw diff output from diffyml. May be truncated for very large diffs (GitHub Actions ~1MB output limit).'
@@ -94,8 +94,8 @@ runs:
         mkdir -p ~/.diffyml/bin
         cd ~/.diffyml
 
-        curl -fsSL -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
         curl -fsSL -o checksums.txt "${BASE_URL}/checksums.txt"
+        curl -fsSL -o "$ARCHIVE" "${BASE_URL}/${ARCHIVE}"
 
         if command -v sha256sum &>/dev/null; then
           grep -F "$ARCHIVE" checksums.txt | sha256sum --check -
@@ -142,7 +142,9 @@ runs:
 
         echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
 
-        if [ "$EXIT_CODE" -eq 1 ]; then
+        if [ "$EXIT_CODE" -gt 1 ]; then
+          echo "has-differences=" >> "$GITHUB_OUTPUT"
+        elif [ "$EXIT_CODE" -eq 1 ]; then
           echo "has-differences=true" >> "$GITHUB_OUTPUT"
         else
           echo "has-differences=false" >> "$GITHUB_OUTPUT"

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: 'true'
   extra-args:
-    description: 'Additional CLI flags passed verbatim to diffyml (e.g. "--ignore-order-changes --filter spec.replicas")'
+    description: 'Additional CLI flags passed verbatim to diffyml (e.g. "--ignore-order-changes --filter spec.replicas"). Split on whitespace; values with spaces are not supported.'
     required: false
     default: ''
 
@@ -42,7 +42,7 @@ outputs:
     description: 'Whether differences were found (true/false)'
     value: ${{ steps.diff.outputs.has-differences }}
   diff:
-    description: 'Raw diff output from diffyml'
+    description: 'Raw diff output from diffyml. May be truncated for very large diffs (GitHub Actions ~1MB output limit).'
     value: ${{ steps.diff.outputs.diff }}
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ outputs:
     description: 'Whether differences were found (true/false, empty on error)'
     value: ${{ steps.diff.outputs.has-differences }}
   diff:
-    description: 'Raw diff output from diffyml. May be truncated for very large diffs (GitHub Actions ~1MB output limit).'
+    description: 'Raw diff output from diffyml (truncated to 1 MB)'
     value: ${{ steps.diff.outputs.diff }}
 
 runs:
@@ -150,10 +150,16 @@ runs:
           echo "has-differences=false" >> "$GITHUB_OUTPUT"
         fi
 
+        MAX_OUTPUT_BYTES=1000000
+        STDOUT_SIZE=$(wc -c < "$RUNNER_TEMP/diffyml_stdout.txt")
+        if [ "$STDOUT_SIZE" -gt "$MAX_OUTPUT_BYTES" ]; then
+          echo "::warning::Diff output truncated from ${STDOUT_SIZE} to ${MAX_OUTPUT_BYTES} bytes"
+        fi
+
         DELIM="DIFFYML_EOF_$(head -c 16 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 16)"
         {
           echo "diff<<$DELIM"
-          cat "$RUNNER_TEMP/diffyml_stdout.txt"
+          head -c "$MAX_OUTPUT_BYTES" "$RUNNER_TEMP/diffyml_stdout.txt"
           echo "$DELIM"
         } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What

Add a composite GitHub Action (`action.yml`) that downloads diffyml from GitHub releases and runs it, with CI annotations, exit code handling, and output capture.

## Why

Listed as a roadmap item. Users should be able to `uses: szhekpisov/diffyml@v1` in their workflows without manual binary installation.

## How

- **Composite action** — downloads pre-built binary from GitHub releases with SHA256 checksum verification and optional caching. No Docker or JS runtime needed.
- **7 inputs**: `from`, `to` (required); `version`, `output`, `fail-on-diff`, `cache`, `extra-args` (optional). All CLI flags available via `extra-args`.
- **3 outputs**: `exit-code`, `has-differences`, `diff` for downstream steps.
- **Security**: all user inputs passed via `env:` (not `${{ }}` interpolation), `grep -F` with space-anchored filename for literal checksum matching, random heredoc delimiter. Checksums downloaded before archive to fail fast on missing releases.
- **`has-differences` semantics**: `true` (exit 1), `false` (exit 0), empty string (exit >1 / error) — callers can distinguish "no diff" from "tool errored".
- **Test workflow** on ubuntu + macos (`fail-fast: false`) with 8 test cases (diff detected, no diff, JSON output, fail-on-diff, extra-args, version pinning, cache disabled, latest resolution).
- **README** updated with usage examples and input/output tables.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [ ] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%) — N/A (no Go changes)
- [x] No new dependencies (or justified)

## Notes for reviewers

- `--set-exit-code` is always passed; `fail-on-diff` controls whether exit code 1 actually fails the step
- The action resolves `latest` via `gh api` (authenticated with `github.token` to avoid rate limits)
- Exit codes > 1 are treated as errors (not just 255)
- Checksum grep uses `grep -F " $ARCHIVE"` (space-prefixed) to avoid matching `.spdx.json` suffix files
- `actions/cache` pinned to v5.0.4 (Node.js 24 compatible)