### PR TITLE
chore: update issue templates to match current feature set

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,7 +35,8 @@ body:
       label: Command and flags
       description: >-
         The exact command you ran. Flags like --detect-kubernetes, --chroot,
-        and --filter-regexp trigger different code paths, so include them all.
+        --filter-regexp, --summary, --config, and --ignore-order-changes
+        trigger different code paths, so include them all.
       placeholder: diffyml --detect-kubernetes old.yaml new.yaml
       render: bash
     validations:
@@ -65,12 +66,14 @@ body:
       label: Output format
       description: Which output format were you using?
       options:
-        - pretty (default)
+        - detailed (default)
+        - compact
+        - brief
         - github
         - gitlab
+        - gitea
         - json
-        - quiet
-        - summary
+        - json-patch
     validations:
       required: true
 
@@ -85,6 +88,8 @@ body:
         - label: YAML anchors/aliases
         - label: Remote URL input
         - label: Large files (>1000 lines)
+        - label: Directory comparison
+        - label: Config file (.diffyml.yml) in use
 
   - type: input
     id: version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -43,6 +43,12 @@ body:
         - Performance
         - CI integration
         - Remote file support
+        - AI summary
+        - Configuration file
+        - Colors / accessibility
+        - Certificate inspection
+        - Directory comparison
+        - Git integration
         - Other
     validations:
       required: true


### PR DESCRIPTION
## What

Sync GitHub issue templates with the current diffyml feature set.

## Why

The bug report output format dropdown listed stale values (`pretty`, `quiet`, `summary`) and was missing current formats (`detailed`, `compact`, `brief`, `gitea`, `json-patch`). The feature request area dropdown didn't cover newer capabilities like AI summaries, config file support, colors, or certificate inspection.

## How

- **bug_report.yml**: replaced output format dropdown options, added missing flags to the command description, added `Directory comparison` and `Config file` input characteristic checkboxes.
- **feature_request.yml**: added 6 new area options (AI summary, Configuration file, Colors / accessibility, Certificate inspection, Directory comparison, Git integration).

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [ ] New/changed behavior covered by tests
- [ ] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Template-only change — no code or test impact.