### PR TITLE
doc: add FOSSA license compliance badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A fast, structural YAML diff tool with built-in Kubernetes intelligence. One dep
 [![codecov](https://codecov.io/gh/szhekpisov/diffyml/branch/main/graph/badge.svg)](https://codecov.io/gh/szhekpisov/diffyml)
 [![Release](https://img.shields.io/github/v/release/szhekpisov/diffyml)](https://github.com/szhekpisov/diffyml/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://github.com/szhekpisov/diffyml/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/szhekpisov/diffyml/actions/workflows/test.yml)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml?ref=badge_shield&issueType=license)
 [![Security & Static Analysis](https://github.com/szhekpisov/diffyml/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/szhekpisov/diffyml/actions/workflows/security.yml)
 
 <img src="doc/demo.png" alt="diffyml output" width="600">


### PR DESCRIPTION
## What

Replace the GitHub Actions Tests badge with a FOSSA license compliance shield in the README badge row.

## Why

Add automated license compliance scanning visibility via FOSSA, giving contributors and users confidence that all dependencies meet licensing requirements.

## How

Swapped the Tests CI badge for the FOSSA shield badge pointing to the project's FOSSA dashboard.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Doc-only change — single badge swap in the README header.