### PR TITLE
doc: update FOSSA badge to security issue type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A fast, structural YAML diff tool with built-in Kubernetes intelligence. One dep
 [![codecov](https://codecov.io/gh/szhekpisov/diffyml/branch/main/graph/badge.svg)](https://codecov.io/gh/szhekpisov/diffyml)
 [![Release](https://img.shields.io/github/v/release/szhekpisov/diffyml)](https://github.com/szhekpisov/diffyml/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml?ref=badge_shield&issueType=license)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml?ref=badge_shield&issueType=security)
 [![Security & Static Analysis](https://github.com/szhekpisov/diffyml/actions/workflows/security.yml/badge.svg?branch=main)](https://github.com/szhekpisov/diffyml/actions/workflows/security.yml)
 
 <img src="doc/demo.png" alt="diffyml output" width="600">


### PR DESCRIPTION
## What

Update the FOSSA badge in README.md from `issueType=license` to `issueType=security`.

## Why

Show FOSSA security scan status instead of license compliance status, aligning the badge with the project's security-focused CI badges.

## How

Changed the `issueType` query parameter in both the badge image URL and the badge link from `license` to `security`.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Docs-only change — single line in README badge section.