### PR TITLE
chore: bump Go toolchain from 1.26.1 to 1.26.2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run benchmarks
         run: go test -bench=. -benchmem -count=1 -benchtime=100ms -timeout=5m ./pkg/diffyml/

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Install gremlins
         run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: false
 
       - name: Run tests
@@ -67,7 +67,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
           cache: false
 
       - name: Install cosign

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -81,6 +81,6 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run tests
         run: go test -race ./...
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run fuzz tests
         run: |
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.1"
+          go-version: "1.26.2"
 
       - name: Run tests with coverage
         run: go test ./pkg/diffyml/ -coverprofile=coverage.out

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Contributions welcome! [Open an issue](https://github.com/szhekpisov/diffyml/iss
 <details>
 <summary>Development setup</summary>
 
-**Prerequisites:** Go 1.26.1+, [pre-commit](https://pre-commit.com/)
+**Prerequisites:** Go 1.26.2+, [pre-commit](https://pre-commit.com/)
 
 ```bash
 git clone https://github.com/szhekpisov/diffyml.git

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/szhekpisov/diffyml
 
-go 1.26.1
+go 1.26.2
 
 require gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## What

Bump the pinned Go version from 1.26.1 to 1.26.2 in `go.mod`, all CI workflows, and the README dev-setup note.

## Why

The scheduled `Security & Static Analysis` workflow is red — govulncheck flags 4 Go stdlib vulnerabilities reachable from our CLI/HTTP paths, all fixed in 1.26.2:

- [GO-2026-4866](https://pkg.go.dev/vuln/GO-2026-4866) — `crypto/x509`: case-sensitive `excludedSubtrees` name-constraint auth bypass
- [GO-2026-4870](https://pkg.go.dev/vuln/GO-2026-4870) — `crypto/tls`: unauthenticated TLS 1.3 KeyUpdate → persistent conn retention / DoS
- [GO-2026-4946](https://pkg.go.dev/vuln/GO-2026-4946) — `crypto/x509`: inefficient policy validation
- [GO-2026-4947](https://pkg.go.dev/vuln/GO-2026-4947) — `crypto/x509`: unexpected work during chain building

Failing run: https://github.com/szhekpisov/diffyml/actions/runs/24331844852

## How

Pure toolchain bump — no code changes. Updated:

- `go.mod` (`go 1.26.1` → `1.26.2`)
- `.github/workflows/{test,mutation,security,benchmark,release}.yml` (all `setup-go` steps)
- `README.md` Prerequisites note

`doc/PERFORMANCE.md` intentionally left at 1.26.1 — it documents historical benchmark environment metadata, not a requirement.

Local `go build ./...` and `go vet ./...` pass on 1.26.2.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Once merged, the scheduled security scan (Mondays 06:00 UTC, or any manual re-run) should go green.