### PR TITLE
doc: README cleanup — action link, trim K8s, surface security, reorder Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,32 @@ Use `-s` / `--set-exit-code` to set the exit code based on differences:
 diffyml -s before.yaml after.yaml || echo "Config drift detected"
 ```
 
+**GitHub Actions** — use the [`diffyml-action`](https://github.com/szhekpisov/diffyml-action) composite action (no manual binary install):
+
+```yaml
+- uses: szhekpisov/diffyml-action@v1
+  with:
+    from: old.yaml
+    to: new.yaml
+```
+
+To inspect drift without failing the job, read the `has-differences` output:
+
+```yaml
+- uses: szhekpisov/diffyml-action@v1
+  id: diff
+  with:
+    from: old.yaml
+    to: new.yaml
+    fail-on-diff: 'false'
+    output: github
+
+- if: steps.diff.outputs.has-differences == 'true'
+  run: echo "Configuration drift detected"
+```
+
+See the [action repo](https://github.com/szhekpisov/diffyml-action) for the full list of inputs and outputs.
+
 ### AI Summary
 
 Generate a natural language summary of changes using the Anthropic API:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ diffyml compares YAML files and shows meaningful, structured differences — not
   - [Custom Colors](#custom-colors)
   - [All Flags](#all-flags)
 - [Library Usage](#library-usage)
-- [Code Quality](#code-quality)
+- [Security & Code Quality](#security--code-quality)
 - [Contributing](#contributing)
 - [Acknowledgments](#acknowledgments)
 - [License](#license)
@@ -98,14 +98,15 @@ go build -o diffyml
 
 ### Verifying Releases
 
-Published release artifacts are never modified or re-uploaded — each version is a one-time, append-only event.
-
-Every release includes cryptographic verification artifacts:
+Published release artifacts are never modified or re-uploaded — each version is a one-time, append-only event. Every release includes:
 
 - **Checksums** (`checksums.txt`) — SHA256 hashes for all archives
 - **Cosign signature** (`checksums.txt.sigstore.json`) — keyless Sigstore signature
 - **SBOMs** (`*.spdx.json`) — SPDX Software Bill of Materials for each archive
 - **SLSA provenance** — Level 3 provenance attestation
+
+<details>
+<summary>Verification commands</summary>
 
 **Verify the checksums signature:**
 
@@ -127,6 +128,8 @@ shasum -a 256 --check checksums.txt --ignore-missing
 gh attestation verify diffyml_<VERSION>_linux_amd64.tar.gz \
   --repo szhekpisov/diffyml
 ```
+
+</details>
 
 ## Quick Start
 
@@ -444,11 +447,13 @@ fmt.Print(formatter.Format(diffs, diffyml.DefaultFormatOptions()))
 
 See the [package documentation](https://pkg.go.dev/github.com/szhekpisov/diffyml/pkg/diffyml) for the full API reference.
 
-## Code Quality
+## Security & Code Quality
 
-Every push and PR is checked by:
+**Supply chain.** Releases are signed with [cosign](https://docs.sigstore.dev/) (keyless Sigstore), ship [SPDX](https://spdx.dev/) SBOMs for every artifact, and carry [SLSA Level 3](https://slsa.dev/spec/v1.0/levels#build-l3) build provenance. Published tags are immutable. See [Verifying Releases](#verifying-releases) for verification commands. The repo is tracked by [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/szhekpisov/diffyml) (badge above).
 
-- [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) — known vulnerability detection
+**Continuous checks.** Every push and PR is scanned by:
+
+- [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) — known vulnerability detection (runs on `main` weekly as well)
 - [zizmor](https://github.com/zizmorcore/zizmor-action) — GitHub Actions workflow security scanning
 - [golangci-lint](https://golangci-lint.run/) running:
   [errcheck](https://github.com/kisielk/errcheck),
@@ -459,7 +464,9 @@ Every push and PR is checked by:
   [misspell](https://github.com/client9/misspell),
   [staticcheck](https://staticcheck.dev/) (all checks except style conventions)
 
-1,500+ tests (unit, e2e, fuzz, property-based), 99.4% code coverage, 100% [mutation testing](https://github.com/go-gremlins/gremlins) efficacy (686/686 mutants killed). CI enforces a 99% coverage floor.
+**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 99.4% code coverage, 100% [mutation testing](https://github.com/go-gremlins/gremlins) efficacy (686/686 mutants killed). CI enforces a 99% coverage floor.
+
+**Reporting vulnerabilities.** See [SECURITY.md](SECURITY.md) — preferred path is a [private GitHub Security Advisory](https://github.com/szhekpisov/diffyml/security/advisories/new).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ diffyml compares YAML files and shows meaningful, structured differences — not
 - [Features](#features)
 - [Usage](#usage)
   - [Output Formats](#output-formats)
+  - [CI Integration](#ci-integration)
   - [Kubernetes Support](#kubernetes-support)
   - [Directory Comparison](#directory-comparison)
   - [Git Integration](#git-integration)
-  - [Filtering](#filtering)
-  - [CI Integration](#ci-integration)
   - [AI Summary](#ai-summary)
+  - [Filtering](#filtering)
   - [Configuration File](#configuration-file)
   - [Custom Colors](#custom-colors)
   - [All Flags](#all-flags)
@@ -180,6 +180,46 @@ diffyml [flags] <from> <to>
 | gitea | `-o gitea` | Gitea CI annotations |
 | json | `-o json` | Machine-readable — piping, scripting, CI |
 
+### CI Integration
+
+Use `-s` / `--set-exit-code` to set the exit code based on differences:
+
+| Exit code | Meaning |
+|-----------|---------|
+| `0` | No differences (or success without `-s`) |
+| `1` | Differences detected (only with `-s`) |
+| `255` | Error occurred |
+
+```bash
+diffyml -s before.yaml after.yaml || echo "Config drift detected"
+```
+
+**GitHub Actions** — use the [`diffyml-action`](https://github.com/szhekpisov/diffyml-action) composite action (no manual binary install):
+
+```yaml
+- uses: szhekpisov/diffyml-action@v1
+  with:
+    from: old.yaml
+    to: new.yaml
+```
+
+To inspect drift without failing the job, read the `has-differences` output:
+
+```yaml
+- uses: szhekpisov/diffyml-action@v1
+  id: diff
+  with:
+    from: old.yaml
+    to: new.yaml
+    fail-on-diff: 'false'
+    output: github
+
+- if: steps.diff.outputs.has-differences == 'true'
+  run: echo "Configuration drift detected"
+```
+
+See the [action repo](https://github.com/szhekpisov/diffyml-action) for the full list of inputs and outputs.
+
 ### Kubernetes Support
 
 Resources are auto-detected and matched by `apiVersion` + `kind` + `metadata.name` (or `metadata.generateName`), so diffs stay meaningful even when document order changes.
@@ -237,59 +277,6 @@ git config diff.diffyml.command diffyml
 
 Color and truecolor are auto-forced (git's pager makes stdout a pipe). Use `--color never` to disable. `--set-exit-code` is silently ignored — git aborts external diff programs that exit non-zero. Parse errors are non-fatal: a warning is printed and git continues to the next file.
 
-### Filtering
-
-```bash
-# Show only changes under a specific path
-diffyml --filter spec.replicas old.yaml new.yaml
-
-# Exclude noisy paths
-diffyml --exclude metadata.annotations old.yaml new.yaml
-
-# Regex filtering
-diffyml --filter-regexp 'spec\.containers\[.*\]\.image' old.yaml new.yaml
-```
-
-### CI Integration
-
-Use `-s` / `--set-exit-code` to set the exit code based on differences:
-
-| Exit code | Meaning |
-|-----------|---------|
-| `0` | No differences (or success without `-s`) |
-| `1` | Differences detected (only with `-s`) |
-| `255` | Error occurred |
-
-```bash
-diffyml -s before.yaml after.yaml || echo "Config drift detected"
-```
-
-**GitHub Actions** — use the [`diffyml-action`](https://github.com/szhekpisov/diffyml-action) composite action (no manual binary install):
-
-```yaml
-- uses: szhekpisov/diffyml-action@v1
-  with:
-    from: old.yaml
-    to: new.yaml
-```
-
-To inspect drift without failing the job, read the `has-differences` output:
-
-```yaml
-- uses: szhekpisov/diffyml-action@v1
-  id: diff
-  with:
-    from: old.yaml
-    to: new.yaml
-    fail-on-diff: 'false'
-    output: github
-
-- if: steps.diff.outputs.has-differences == 'true'
-  run: echo "Configuration drift detected"
-```
-
-See the [action repo](https://github.com/szhekpisov/diffyml-action) for the full list of inputs and outputs.
-
 ### AI Summary
 
 Generate a natural language summary of changes using the Anthropic API:
@@ -308,6 +295,19 @@ diffyml --summary --summary-model claude-sonnet-4-5-20250514 old.yaml new.yaml
 ```
 
 The summary is appended after the standard diff output. If the API call fails, a warning is printed to stderr and the diff output is preserved. The exit code is never affected by summary success or failure.
+
+### Filtering
+
+```bash
+# Show only changes under a specific path
+diffyml --filter spec.replicas old.yaml new.yaml
+
+# Exclude noisy paths
+diffyml --exclude metadata.annotations old.yaml new.yaml
+
+# Regex filtering
+diffyml --filter-regexp 'spec\.containers\[.*\]\.image' old.yaml new.yaml
+```
 
 ### Configuration File
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ diffyml compares YAML files and shows meaningful, structured differences — not
 
 - [Why diffyml?](#why-diffyml)
 - [How It Compares](#how-it-compares)
-- [Kubernetes Intelligence](#kubernetes-intelligence)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
@@ -67,14 +66,6 @@ diffyml compares YAML files and shows meaningful, structured differences — not
 | Performance (780 KB) | 128 ms | 1,214 ms (9.49x slower) | 46 ms |
 
 Comparison based on dyff v1.11.2 and diffyml v1.5.13. See [PERFORMANCE.md](doc/PERFORMANCE.md) for benchmark methodology. [Open an issue](https://github.com/szhekpisov/diffyml/issues) if anything is outdated.
-
-## Kubernetes Intelligence
-
-diffyml auto-detects Kubernetes resources and matches them by `apiVersion`, `kind`, and `metadata.name` (or `metadata.generateName`) — so diffs stay meaningful even when document order changes.
-
-- **Rename detection** — detects renamed/moved resources by content similarity (e.g., kustomize `configMapGenerator` hash-suffix changes like `app-config-abc123` → `app-config-def456`) and shows field-level diffs instead of bulk add/remove
-- **API migration support** — `--ignore-api-version` drops `apiVersion` from the matching key, so an upgrade from `apps/v1beta1` to `apps/v1` shows field-level diffs instead of a remove + add
-- **Drop-in for kubectl** — compare two directories of YAML files and use as `KUBECTL_EXTERNAL_DIFF` with no extra setup
 
 ## Installation
 


### PR DESCRIPTION
## What

Four small, related README cleanups on the same branch that together tighten the reader's journey and better surface existing trust signals.

1. **Add a link to the standalone [`diffyml-action`](https://github.com/szhekpisov/diffyml-action)** inside the existing `### CI Integration` subsection, with a minimal `uses:` example and a non-blocking (`fail-on-diff: 'false'`) outputs example.
2. **Remove the top-level `## Kubernetes Intelligence` section.** It duplicated content already carried by the tagline, the "How It Compares" table, and the nested `### Kubernetes Support` subsection under Usage (which documents it in more detail: 60% rename-similarity threshold, `--detect-renames=false`, `--detect-kubernetes=false` opt-out). ToC entry removed too.
3. **Consolidate supply-chain signals** into a renamed `## Security & Code Quality` section (was `## Code Quality`). Added a "Supply chain" lead-in paragraph that pulls together cosign, SPDX SBOMs, SLSA-3 provenance, immutable tags, and the OpenSSF Scorecard badge — signals that were previously scattered between badges, the Verify Releases block, and Code Quality. Also added a "Reporting vulnerabilities" pointer to `SECURITY.md`. Collapsed the `### Verifying Releases` command block into a `<details>` toggle so ~20 lines of cosign/SLSA commands no longer sit on the install-to-run path.
4. **Reorder `## Usage` subsections by user impact** into a rough pyramid:
   - **Core workflows** (top): Output Formats, CI Integration, Kubernetes Support, Directory Comparison
   - **Integrations**: Git Integration, AI Summary
   - **Power-user / refinement**: Filtering, Configuration File, Custom Colors
   - **Reference** (bottom): All Flags

## Why

Applied the standard OSS README arc (Hook → Value prop → Install → Hello world → Feature surface → Reference → Trust signals), treating the README as a reader journey where each stage has a different time budget and mindset:

- **K8s Intelligence removal** — three K8s pitches (tagline, comparison table, dedicated section) before Installation was over-selling and gatekeeping non-K8s readers. The dedicated section added no new information over `### Kubernetes Support` under Usage.
- **Verifying Releases collapse** — immutable/signed/SBOM is a strong trust signal, but 20 lines of hands-on cosign commands sit in the critical install-to-run path. Keep the signal visible (artifact list), collapse the commands as reference material.
- **Consolidated Security & Code Quality** — this project has a serious supply-chain posture (Scorecard, cosign, SBOMs, SLSA-3, `govulncheck` weekly scan, 99% coverage floor, 100% mutation-test efficacy). Previously those signals were split across three places. One consolidated section makes the story legible.
- **Action link** — the action lives in its own repo (see closing comment on #69); GitHub-workflow users had no discoverable path to it from this repo.
- **Usage reorder** — `### CI Integration` was mid-section despite being a top use case (and now has a concrete GitHub Actions entry point via `diffyml-action`). `### Filtering` was higher than it deserved — it's useful but technique-level rather than workflow-level.

## How

Four commits on `update-readme`, each independently revertable:

1. `doc: link to diffyml-action in CI Integration section` — bolded **GitHub Actions** lead-in (not a new `###` heading) so no new ToC entry is needed; two YAML snippets + link to the action repo for full input/output reference.
2. `doc: remove redundant Kubernetes Intelligence section` — pure deletion; no content merge needed.
3. `doc: consolidate supply-chain signals under Security & Code Quality` — `<details>` wrap of Verifying Releases commands, renamed section, new Supply chain + Reporting paragraphs, ToC updated.
4. `doc: reorder Usage subsections by user impact` — content of each subsection unchanged; purely a reorder with matching ToC update.

Resulting top-level flow: `Why → How It Compares → Installation → Quick Start → Features → Usage → Library Usage → Security & Code Quality → Contributing → Acknowledgments → License`.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Doc-only — no code, no behavior changes. Each commit is independently revertable.