### PR TITLE
chore: migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -22,7 +22,7 @@ jobs:
             echo "  bug: fix K8s resource matching for namespaced resources"
             echo "  fix: correct YAML indentation in multi-doc output"
             echo "  doc: update contributing guidelines"
-            echo "  chore: bump gopkg.in/yaml.v3 to v3.1.0"
+            echo "  chore: bump go.yaml.in/yaml/v3 to v3.1.0"
             echo "  test: add fixture for directory comparison"
             exit 1
           fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
           allow:
             - $gostd
             - github.com/szhekpisov/diffyml
-            - gopkg.in/yaml.v3
+            - go.yaml.in/yaml/v3
     errcheck:
       # Terminal output and cleanup — errors are intentionally ignored
       exclude-functions:

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/szhekpisov/diffyml
 
 go 1.26.2
 
-require gopkg.in/yaml.v3 v3.0.1
+require go.yaml.in/yaml/v3 v3.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/diffyml/cli/config.go
+++ b/pkg/diffyml/cli/config.go
@@ -12,7 +12,7 @@ import (
 	"os"
 
 	"github.com/szhekpisov/diffyml/pkg/diffyml"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // FileConfig represents the YAML configuration file structure.

--- a/pkg/diffyml/coverage_gaps_test.go
+++ b/pkg/diffyml/coverage_gaps_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // Tests targeting remaining coverage gaps identified by gremlins mutation testing.

--- a/pkg/diffyml/ordered_map.go
+++ b/pkg/diffyml/ordered_map.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // OrderedMap is a map that preserves insertion order of keys.

--- a/pkg/diffyml/ordered_map_coverage_test.go
+++ b/pkg/diffyml/ordered_map_coverage_test.go
@@ -3,7 +3,7 @@ package diffyml
 import (
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNodeToInterface_EdgeCases(t *testing.T) {

--- a/pkg/diffyml/parser.go
+++ b/pkg/diffyml/parser.go
@@ -1,6 +1,6 @@
 // parser.go - YAML parsing wrapper.
 //
-// Wraps gopkg.in/yaml.v3 to parse YAML content into Go any values.
+// Wraps go.yaml.in/yaml/v3 to parse YAML content into Go any values.
 // Handles multi-document YAML files (--- separators).
 // Key types: ParseError (with line/column info), DocumentParser (streaming).
 package diffyml
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // DocumentParser allows incremental parsing of multi-document YAML.

--- a/pkg/diffyml/parser_coverage_test.go
+++ b/pkg/diffyml/parser_coverage_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // drainDocumentParser reads all documents from a DocumentParser and returns them.

--- a/pkg/diffyml/rename.go
+++ b/pkg/diffyml/rename.go
@@ -5,7 +5,7 @@ import (
 	"hash/crc32"
 	"slices"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/pkg/diffyml/serialize.go
+++ b/pkg/diffyml/serialize.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // marshalStructuredYAML marshals structured types (*OrderedMap, map[string]any,


### PR DESCRIPTION
## What

Migrate the YAML dependency from `gopkg.in/yaml.v3` (v3.0.1) to `go.yaml.in/yaml/v3` (v3.0.4).

## Why

The original `go-yaml/yaml` repository is [archived and unmaintained](https://github.com/go-yaml/yaml). The YAML org's fork at `yaml/go-yaml` is the actively maintained successor, coordinated with the original author. The fork includes bug fixes we don't currently get:

- Panic fix for unhashable merge-tag map keys
- Compact sequence indent support (Kubernetes-style)
- Literal/folded scalar leading newline fix

## How

Pure import-path swap — no API changes. Updated:
- `go.mod` / `go.sum`
- 8 Go source files (import paths)
- `.golangci.yml` (depguard allowlist)
- `.github/workflows/pr-title.yml` (example commit message)

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

This is a drop-in replacement — same API, no breaking changes. The fork's v3 branch is frozen (security-only); active development is on v4. We can consider v4 as a follow-up when it reaches stable.