### PR TITLE
chore: tighten workflow permissions and pin go install commands

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,6 +1,7 @@
 name: Benchmark Smoke Check
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: CodeQL
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/bench/compare/run.sh
+++ b/bench/compare/run.sh
@@ -143,20 +143,20 @@ if [ "$SKIP_INSTALL" = false ]; then
   ok "diffyml built"
 
   info "Installing dyff..."
-  GOBIN="$TOOL_DIR" go install github.com/homeport/dyff/cmd/dyff@v1.11.3
+  GOBIN="$TOOL_DIR" go install github.com/homeport/dyff/cmd/dyff@4512053136bcd17cc8784b386f6c75bda7e01ec2 # v1.11.3
   ok "dyff installed"
 
   info "Installing semihbkgr/yamldiff..."
-  GOBIN="$TOOL_DIR" go install github.com/semihbkgr/yamldiff@v0.3.1
+  GOBIN="$TOOL_DIR" go install github.com/semihbkgr/yamldiff@1179190f34163df0a03e702d3597fd07863d2f9d # v0.3.1
   mv "$TOOL_DIR/yamldiff" "$TOOL_DIR/yamldiff-semihbkgr"
   ok "yamldiff-semihbkgr installed"
 
   info "Installing sters/yaml-diff..."
-  GOBIN="$TOOL_DIR" go install github.com/sters/yaml-diff/cmd/yaml-diff@v1.4.1
+  GOBIN="$TOOL_DIR" go install github.com/sters/yaml-diff/cmd/yaml-diff@a570d2fe557fd127a2b1fe9bff9e75e0cf5a8f6b # v1.4.1
   ok "yaml-diff installed"
 
   info "Installing sahilm/yamldiff..."
-  GOBIN="$TOOL_DIR" go install github.com/sahilm/yamldiff@1.3
+  GOBIN="$TOOL_DIR" go install github.com/sahilm/yamldiff@584d5771767b262cf171d9c1f890d6daeb82492c # 1.3
   mv "$TOOL_DIR/yamldiff" "$TOOL_DIR/yamldiff-sahilm"
   ok "yamldiff-sahilm installed"
 


### PR DESCRIPTION
## What

Closes three open code-scanning alerts:

- [#63](https://github.com/szhekpisov/diffyml/security/code-scanning/63) — zizmor `excessive-permissions` on `benchmark.yml`
- [#64](https://github.com/szhekpisov/diffyml/security/code-scanning/64) — zizmor `excessive-permissions` on `codeql.yml`
- [#65](https://github.com/szhekpisov/diffyml/security/code-scanning/65) — Scorecard `PinnedDependenciesID` on `bench/compare/run.sh`

## Why

These are the subset of currently-open code-scanning findings that can be fixed by a code change. The rest (`#1`, `#29`, `#30`, `#31`, `#32`) are repo-settings / process / time-based, and `#48` is a known upstream limitation (SLSA reusable workflow must be referenced by tag, not SHA — the workflow reads its own ref at runtime to compute provenance).

## How

- **`.github/workflows/benchmark.yml`** — replace `permissions: read-all` with `contents: read` at the workflow level. Both jobs only check out the repo and run Go tests, so nothing else is needed.
- **`.github/workflows/codeql.yml`** — same top-level change. Because job-level `permissions:` **replaces** (not extends) workflow-level, the `analyze` job now explicitly re-declares `contents: read` and `actions: read` alongside its existing `security-events: write`, matching the [documented CodeQL requirements](https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning).
- **`bench/compare/run.sh`** — all four `go install` commands now pin to a full commit SHA (resolved via `git ls-remote` against each upstream repo), with the original tag kept as a trailing comment for readability.

## Checklist

- [x] PR title follows convention (`chore:`)
- [x] `bash -n bench/compare/run.sh` passes (no Go code touched, so `make ci` is not applicable here)
- [ ] New/changed behavior covered by tests — N/A (CI/script config only)
- [ ] Coverage thresholds met — N/A
- [x] No new dependencies

## Notes for reviewers

- Scorecard's next scheduled run on `main` should auto-close #63, #64, #65.
- Recommend dismissing #48 separately as "won't fix" with a pointer to the SLSA upstream constraint.