### PR TITLE
feat: publish multi-arch Docker images to GHCR with pre-push scan

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
       day: "monday"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -1,0 +1,33 @@
+name: Container scan
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan ghcr.io/szhekpisov/diffyml:latest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Scan image with Grype
+        uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+        id: grype
+        with:
+          image: "ghcr.io/szhekpisov/diffyml:latest"
+          fail-build: true
+          severity-cutoff: high
+          output-format: sarif
+
+      - name: Upload Grype SARIF
+        if: always() && steps.grype.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+          category: grype-image-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,19 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      packages: write
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Lint Dockerfile with hadolint
+        uses: hadolint/hadolint-action@3fc49fb50d59c6ab7917a2e4195dba633e515b29 # v3.2.0
+        with:
+          dockerfile: Dockerfile.goreleaser
+          failure-threshold: warning
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -75,6 +83,19 @@ jobs:
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         id: goreleaser
@@ -98,6 +119,100 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-checksums: ./dist/checksums.txt
+
+      - name: Export per-arch images for scanning
+        id: images
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          mkdir -p image-tars
+          for arch in amd64 arm64; do
+            IMG="ghcr.io/szhekpisov/diffyml:${VERSION}-${arch}"
+            docker save "$IMG" -o "image-tars/diffyml-${arch}.tar"
+          done
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Scan amd64 image with Grype
+        uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+        id: grype-amd64
+        with:
+          path: image-tars/diffyml-amd64.tar
+          fail-build: true
+          severity-cutoff: high
+          output-format: sarif
+
+      - name: Upload Grype amd64 SARIF
+        if: always() && steps.grype-amd64.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: ${{ steps.grype-amd64.outputs.sarif }}
+          category: grype-image-amd64
+
+      - name: Scan arm64 image with Grype
+        uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
+        id: grype-arm64
+        with:
+          path: image-tars/diffyml-arm64.tar
+          fail-build: true
+          severity-cutoff: high
+          output-format: sarif
+
+      - name: Upload Grype arm64 SARIF
+        if: always() && steps.grype-arm64.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        with:
+          sarif_file: ${{ steps.grype-arm64.outputs.sarif }}
+          category: grype-image-arm64
+
+      - name: Push per-arch images to GHCR
+        env:
+          VERSION: ${{ steps.images.outputs.version }}
+        run: |
+          for arch in amd64 arm64; do
+            docker push "ghcr.io/szhekpisov/diffyml:${VERSION}-${arch}"
+          done
+
+      - name: Create multi-arch manifests
+        env:
+          VERSION: ${{ steps.images.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            -t "ghcr.io/szhekpisov/diffyml:${VERSION}" \
+            "ghcr.io/szhekpisov/diffyml:${VERSION}-amd64" \
+            "ghcr.io/szhekpisov/diffyml:${VERSION}-arm64"
+          docker buildx imagetools create \
+            -t "ghcr.io/szhekpisov/diffyml:latest" \
+            "ghcr.io/szhekpisov/diffyml:${VERSION}-amd64" \
+            "ghcr.io/szhekpisov/diffyml:${VERSION}-arm64"
+
+      - name: Resolve manifest digest
+        id: manifest
+        env:
+          VERSION: ${{ steps.images.outputs.version }}
+        run: |
+          IMAGE="ghcr.io/szhekpisov/diffyml:${VERSION}"
+          DIGEST=$(docker buildx imagetools inspect "$IMAGE" | awk '/^Digest:/ {print $2; exit}')
+          if [[ -z "$DIGEST" ]]; then
+            echo "::error::Could not resolve manifest digest for $IMAGE"
+            exit 1
+          fi
+          echo "image=ghcr.io/szhekpisov/diffyml" >> "$GITHUB_OUTPUT"
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Sign manifest with cosign
+        env:
+          IMAGE: ${{ steps.manifest.outputs.image }}
+          DIGEST: ${{ steps.manifest.outputs.digest }}
+        run: |
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Attest image build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ steps.manifest.outputs.image }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
 
   provenance:
     needs: release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -31,6 +32,23 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+            docker:
+              - 'Dockerfile*'
+
+  hadolint:
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Lint Dockerfile with hadolint
+        uses: hadolint/hadolint-action@3fc49fb50d59c6ab7917a2e4195dba633e515b29 # v3.2.0
+        with:
+          dockerfile: Dockerfile.goreleaser
+          failure-threshold: warning
 
   test:
     needs: changes

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -49,6 +49,40 @@ signs:
       - "--yes"
     artifacts: sbom
 
+dockers:
+  - image_templates:
+      - "ghcr.io/szhekpisov/diffyml:{{ .Version }}-amd64"
+    skip_push: true
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.description=Structural diff tool for YAML files"
+      - "--label=org.opencontainers.image.source=https://github.com/szhekpisov/diffyml"
+      - "--label=org.opencontainers.image.url=https://github.com/szhekpisov/diffyml"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+  - image_templates:
+      - "ghcr.io/szhekpisov/diffyml:{{ .Version }}-arm64"
+    skip_push: true
+    use: buildx
+    dockerfile: Dockerfile.goreleaser
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.description=Structural diff tool for YAML files"
+      - "--label=org.opencontainers.image.source=https://github.com/szhekpisov/diffyml"
+      - "--label=org.opencontainers.image.url=https://github.com/szhekpisov/diffyml"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
 brews:
   - repository:
       owner: szhekpisov

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,5 @@
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY diffyml /usr/local/bin/diffyml
+
+ENTRYPOINT ["/usr/local/bin/diffyml"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 COPY diffyml /usr/local/bin/diffyml
 


### PR DESCRIPTION
## What

Publish multi-arch (linux/amd64, linux/arm64) Docker images to `ghcr.io/szhekpisov/diffyml` on every release, with Grype scanning gating the push and OCI-referrer provenance + cosign signing on the final manifest.

## Why

Docker was the highest-leverage distribution channel still missing: CI pipelines without a Go toolchain reach for a container before `brew` or `go install`. Pre-push scanning keeps the existing supply-chain posture (SBOM, cosign, SLSA provenance, attestations) consistent across archives and images.

## How

- **`Dockerfile.goreleaser`** (new): `gcr.io/distroless/static-debian12:nonroot` **pinned by sha256 digest**, single `COPY` of the goreleaser-built binary, JSON-form `ENTRYPOINT`. No shell, no package manager, non-root.
- **`.goreleaser.yaml`**: per-arch `dockers:` entries with `skip_push: true` and `use: buildx`, so images are `--load`ed into the local Docker daemon instead of being pushed immediately. Removed `docker_manifests:` and `docker_signs:` — those are now assembled in the workflow after scanning.
- **`.github/workflows/release.yml`**:
  - `hadolint` lints `Dockerfile.goreleaser` immediately after checkout — fails fast on Dockerfile issues before spending time on setup-go/syft/buildx.
  - QEMU + Buildx + GHCR login; added `packages: write` and `security-events: write` to the release job.
  - After goreleaser: `docker save` each arch image to a tar, scan with `anchore/scan-action@v7.0.0` (`fail-build: true`, `severity-cutoff: high`), upload SARIF to code scanning (`if: always()`), then `docker push` per-arch, `docker buildx imagetools create` to assemble `:<version>` and `:latest`, resolve manifest digest via `docker buildx imagetools inspect`, `cosign sign` the manifest, and `actions/attest-build-provenance` with `push-to-registry: true`.
- **`.github/workflows/container-scan.yml`** (new): weekly Monday 06:00 UTC cron + `workflow_dispatch`, scans `:latest` with Grype, uploads SARIF under category `grype-image-latest` so newly-disclosed CVEs between releases show up in the Security tab.
- **`.github/workflows/test.yml`**: extended the paths-filter with a `docker` output matching `Dockerfile*` and added a `hadolint` job gated on it, so PRs that touch a Dockerfile get the same lint as release.
- **`.github/dependabot.yml`**: added the `docker` ecosystem (weekly Monday + 7-day cooldown, matching the other ecosystems) so base-image digest bumps arrive as PRs instead of silently rolling in.

### Trade-offs / things to watch

- First `v*.*.*` tag creates the GHCR package as **private** by default — visibility has to be flipped manually in the package settings before anonymous `docker pull` works.
- First scheduled run of `container-scan.yml` will fail if no `:latest` exists yet; safe to ignore or trigger manually after the first release.
- Grype at `high` cutoff on distroless+static-Go should rarely hit, but a freshly-disclosed Go stdlib CVE could block a release until Go is bumped. Easy to tune to `critical` if it becomes noisy.
- Load-bearing assumption verified locally via `goreleaser release --snapshot --clean`: goreleaser with `use: buildx` + `skip_push: true` `--load`s images into the local Docker daemon, `docker save` produces ~9 MB tars, Grype returns zero vulnerabilities at `high` cutoff on both arches.

## Checklist

- [x] PR title follows convention (`feat:`)
- [ ] `make ci` passes locally
- [ ] New/changed behavior covered by tests
- [ ] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

- `make ci` / coverage boxes unchecked because this is CI/release-pipeline plumbing — no Go code changes, no new tests added.
- Goreleaser config validated locally with `goreleaser check`; workflows cleared by `zizmor` (no findings).
- Tier 1 local validation: `hadolint` clean, goreleaser snapshot produced per-arch images in the local daemon, `docker save` + `grype docker-archive:` scanned both tars with "No vulnerabilities found".
- The existing deprecation notices from `goreleaser check` (`dockers`/`docker_manifests` → `dockers_v2`, `brews` → `homebrew_casks`) are pre-existing and out of scope for this PR.