### PR TITLE
fix: pass docker-archive scheme to Grype image scans

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         id: grype-amd64
         with:
-          path: image-tars/diffyml-amd64.tar
+          image: docker-archive:image-tars/diffyml-amd64.tar
           fail-build: true
           severity-cutoff: high
           output-format: sarif
@@ -153,7 +153,7 @@ jobs:
         uses: anchore/scan-action@f6601287cdb1efc985d6b765bbf99cb4c0ac29d8 # v7.0.0
         id: grype-arm64
         with:
-          path: image-tars/diffyml-arm64.tar
+          image: docker-archive:image-tars/diffyml-arm64.tar
           fail-build: true
           severity-cutoff: high
           output-format: sarif


### PR DESCRIPTION
## What

Fix the release workflow's Grype scans so they read our `docker save` tarballs as docker archives instead of failing to parse them as directories.

## Why

The v1.5.24 release failed at `Scan amd64 image with Grype` with:

```
failed to catalog: errors occurred attempting to resolve 'image-tars/diffyml-amd64.tar':
  - oci-dir: ... stat image-tars/diffyml-amd64.tar/index.json: not a directory
  - local-directory: not a directory source: image-tars/diffyml-amd64.tar
```

`anchore/scan-action`'s `path:` input prepends `dir:` and hands the value to Grype as a directory source. Our workflow feeds it a tarball produced by `docker save`, so Grype tried `dir:image-tars/diffyml-amd64.tar` and aborted. The release blocked before image push/sign.

## How

Switched the two Grype steps from `path:` to `image: docker-archive:<tar>`. When `image` is set, the action passes the value through to Grype unchanged (`dist/index.js:121-123`), and `docker-archive:` is the Grype/syft scheme for `docker save` tarballs.

No other workflow behavior changed — images are still loaded by buildx with `use: buildx`, saved per-arch, scanned locally, and pushed only if both scans pass.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [ ] `make ci` passes locally (n/a — workflow-only change)
- [ ] New/changed behavior covered by tests (n/a — covered on next tag push)
- [ ] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Only verifiable end-to-end by pushing a new tag. Plan after merge: tag `v1.5.25` and confirm the release workflow gets past the Grype scan steps.