### PR TITLE
chore: use OCI 1.1 referrers mode for cosign signatures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
           IMAGE: ${{ steps.manifest.outputs.image }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
         run: |
-          cosign sign --yes "${IMAGE}@${DIGEST}"
+          cosign sign --yes --registry-referrers-mode=oci-1-1 "${IMAGE}@${DIGEST}"
 
       - name: Attest image build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ gh attestation verify diffyml_<VERSION>_linux_amd64.tar.gz \
   --repo szhekpisov/diffyml
 ```
 
+**Verify the container image signature:**
+
+```bash
+cosign verify \
+  --registry-referrers-mode=oci-1-1 \
+  --certificate-identity-regexp 'https://github.com/szhekpisov/diffyml/' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  ghcr.io/szhekpisov/diffyml:<VERSION>
+```
+
 </details>
 
 ## Quick Start


### PR DESCRIPTION
## What

Switch `cosign sign` to OCI 1.1 referrers mode so image signatures are attached via the referrers API instead of as `sha256-<digest>` sidecar tags. Adds a matching `cosign verify` example to the README.

## Why

The `sha256-<digest>` sidecar tags cosign creates by default show up on the GHCR package page as if they were pullable images, producing confusing `docker pull ghcr.io/szhekpisov/diffyml:sha256-...` rows in the UI. Attempting to pull them fails with `unsupported media type application/vnd.oci.empty.v1+json` because they're signature artifacts, not images. Referrers mode keeps signatures attached to the image digest without adding tags.

## How

- `.github/workflows/release.yml`: add `--registry-referrers-mode=oci-1-1` to the `cosign sign` invocation.
- `README.md`: add a `cosign verify` command under "Verifying Releases" that uses the same flag, so users can verify the signed image.

Existing `sha256-...` tags from past releases are unaffected and will need to be deleted manually from GHCR if desired; new releases will not create them.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [ ] `make ci` passes locally
- [x] New/changed behavior covered by tests — N/A, CI/docs-only change
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%) — N/A
- [x] No new dependencies (or justified)

## Notes for reviewers

- Recent cosign (≥2.2) auto-discovers signatures via the referrers API, so most users won't need to pass `--registry-referrers-mode=oci-1-1` on verify. The flag is shown in the README so the command works even with older tooling.
- End-to-end verification of the new behavior requires cutting a release; the change itself is a single flag.