### PR TITLE
doc: document Docker image install option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ Make sure `$GOPATH/bin` is in your `PATH`:
 export PATH="$(go env GOPATH)/bin:$PATH"
 ```
 
+### Docker
+
+Multi-arch images (linux/amd64, linux/arm64) are published to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/szhekpisov/diffyml:latest
+
+# Compare two files from the current directory
+docker run --rm -v "$PWD:/work" -w /work ghcr.io/szhekpisov/diffyml:latest old.yaml new.yaml
+```
+
+Images are built from a [distroless](https://github.com/GoogleContainerTools/distroless) base and run as a non-root user. Use `:latest` or pin to a specific version (e.g. `:1.5.25`).
+
 ### From Source
 
 ```bash


### PR DESCRIPTION
## What

Document the ghcr.io Docker image as an install option in the README.

## Why

Multi-arch Docker images have been published to `ghcr.io/szhekpisov/diffyml` since #113, but the README's Installation section only covered Homebrew, `go install`, and building from source. Users who prefer containerized tooling (e.g. pipelines that already shell out to `docker run`) had no signposted entry point.

## How

Added a new `### Docker` subsection between `### Go Install` and `### From Source` with:
- `docker pull` / `docker run` snippets (including a volume mount so local files are reachable)
- A note that images are multi-arch (linux/amd64, linux/arm64), distroless-based, and run as a non-root user
- Guidance to pin a version tag (`:1.5.25`) or use `:latest`

No code or behavior changes.

## Checklist

- [x] PR title follows convention (\`doc:\`)
- [ ] \`make ci\` passes locally — N/A, docs-only
- [ ] New/changed behavior covered by tests — N/A, docs-only
- [ ] Coverage thresholds met — N/A, docs-only
- [x] No new dependencies

## Notes for reviewers

The version example (\`:1.5.25\`) matches the tag format published by the release workflow (which strips the leading \`v\` via \`VERSION="\${TAG#v}"\`).