### PR TITLE
fix: auto-enable GitHub Pages in docs deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,5 +100,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        with:
+          enablement: true
       - id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## What

Set \`enablement: true\` on \`actions/configure-pages\` in the Docs workflow so Pages is configured on first run.

## Why

The deploy job of [run 25076546092](https://github.com/szhekpisov/diffyml/actions/runs/25076546092) failed with:

> Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the \`enablement\` parameter for this action. Error: Not Found

GitHub Pages had never been enabled on the repository, so \`configure-pages\` returned HTTP 404. The action's \`enablement\` parameter is the documented way to enable Pages with the GitHub Actions source from a workflow.

## How

Added \`with: enablement: true\` to the \`actions/configure-pages\` step in \`.github/workflows/docs.yml\`. The build job is unaffected.

## Checklist

- [x] PR title follows convention (\`fix:\`)
- [ ] \`make ci\` passes locally — N/A (workflow-only change)
- [ ] New/changed behavior covered by tests — N/A
- [ ] Coverage thresholds met — N/A
- [x] No new dependencies

## Notes for reviewers

The deploy job only runs on \`main\` (\`if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'\`), so this PR's CI will exercise the build job but not the deploy job. The fix needs to land on \`main\` to verify Pages enablement end-to-end.