### PR TITLE
feat: opt-in sensitive value masking

### DIFF
--- a/.diffyml.yml.example
+++ b/.diffyml.yml.example
@@ -63,6 +63,21 @@ chroot-list-to-documents: false
 #     added: "#6aa3a5"
 #     removed: "#702d06"
 
+# Sensitive value masking
+# Opt-in. When enabled, applies to every output format (including json,
+# json-patch, and AI summary). Set mask-secrets to true to auto-mask
+# Kubernetes Secret data/stringData; add custom paths via mask-path.
+mask-secrets: false
+mask-path: []
+mask-path-regexp: []
+mask-placeholder: "***"
+# Example:
+#   mask-path:
+#     - "data.api_key"
+#     - "data.db_url"
+#   mask-path-regexp:
+#     - "(?i)password|token|secret"
+
 # AI Summary (requires ANTHROPIC_API_KEY environment variable)
 summary: false
 summary-model: "claude-haiku-4-5-20251001"

--- a/.github/workflows/_docs-build.yml
+++ b/.github/workflows/_docs-build.yml
@@ -1,0 +1,70 @@
+name: Docs Build (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      upload-artifact:
+        description: Upload Hugo output as a Pages artifact (for deploy).
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+env:
+  # Hugo extended >= 0.146 is required by hugo-book v13.
+  HUGO_VERSION: 0.161.0
+  # Pinned to a release tag for reproducible builds; bump manually when upgrading the theme.
+  HUGO_BOOK_REF: v13
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.2"
+
+      - name: Install Hugo extended
+        run: |
+          set -euo pipefail
+          curl -sSL --fail \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" \
+            -o hugo.tar.gz
+          mkdir hugo-bin
+          tar -xzf hugo.tar.gz -C hugo-bin hugo
+          sudo mv hugo-bin/hugo /usr/local/bin/hugo
+          rm -rf hugo.tar.gz hugo-bin
+          hugo version
+
+      - name: Fetch hugo-book theme
+        run: |
+          set -euo pipefail
+          mkdir -p docs/themes
+          git clone --depth 1 --branch "${HUGO_BOOK_REF}" \
+            https://github.com/alex-shpak/hugo-book.git docs/themes/hugo-book
+          rm -rf docs/themes/hugo-book/.git
+
+      - name: Regenerate CLI reference
+        run: make docs-gen
+
+      - name: Verify CLI reference is up to date
+        run: |
+          if ! git diff --exit-code docs/content/docs/reference.md; then
+            echo "::error::docs/content/docs/reference.md is stale; run 'make docs-gen' and commit"
+            exit 1
+          fi
+
+      - name: Build site
+        working-directory: docs
+        run: hugo --minify
+
+      - name: Upload Pages artifact
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: docs/public

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,18 +1,24 @@
-name: Docs
+name: Docs Deploy
 
 on:
-  pull_request:
+  push:
     branches: [main]
     paths:
       - 'docs/**'
       - 'doc/gen-cli-ref/**'
+      - 'README.md'
       - 'pkg/diffyml/cli/cli.go'
       - 'pkg/diffyml/cli/flag_metadata.go'
-      - '.github/workflows/docs.yml'
+      - '.diffyml.yml.example'
+      - '.github/workflows/docs-deploy.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 env:
   # Hugo extended >= 0.146 is required by hugo-book v13.
@@ -57,13 +63,25 @@ jobs:
       - name: Regenerate CLI reference
         run: make docs-gen
 
-      - name: Verify CLI reference is up to date
-        run: |
-          if ! git diff --exit-code docs/content/docs/reference.md; then
-            echo "::error::docs/content/docs/reference.md is stale; run 'make docs-gen' and commit"
-            exit 1
-          fi
-
       - name: Build site
         working-directory: docs
         run: hugo --minify
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: docs/public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -11,6 +11,7 @@ on:
       - 'pkg/diffyml/cli/flag_metadata.go'
       - '.diffyml.yml.example'
       - '.github/workflows/docs-deploy.yml'
+      - '.github/workflows/_docs-build.yml'
   workflow_dispatch:
 
 permissions:
@@ -20,57 +21,11 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-env:
-  # Hugo extended >= 0.146 is required by hugo-book v13.
-  HUGO_VERSION: 0.161.0
-  # Pinned to a release tag for reproducible builds; bump manually when upgrading the theme.
-  HUGO_BOOK_REF: v13
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26.2"
-
-      - name: Install Hugo extended
-        run: |
-          set -euo pipefail
-          curl -sSL --fail \
-            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" \
-            -o hugo.tar.gz
-          mkdir hugo-bin
-          tar -xzf hugo.tar.gz -C hugo-bin hugo
-          sudo mv hugo-bin/hugo /usr/local/bin/hugo
-          rm -rf hugo.tar.gz hugo-bin
-          hugo version
-
-      - name: Fetch hugo-book theme
-        run: |
-          set -euo pipefail
-          mkdir -p docs/themes
-          git clone --depth 1 --branch "${HUGO_BOOK_REF}" \
-            https://github.com/alex-shpak/hugo-book.git docs/themes/hugo-book
-          rm -rf docs/themes/hugo-book/.git
-
-      - name: Regenerate CLI reference
-        run: make docs-gen
-
-      - name: Build site
-        working-directory: docs
-        run: hugo --minify
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        with:
-          path: docs/public
+    uses: ./.github/workflows/_docs-build.yml
+    with:
+      upload-artifact: true
 
   deploy:
     needs: build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,61 +9,12 @@ on:
       - 'pkg/diffyml/cli/cli.go'
       - 'pkg/diffyml/cli/flag_metadata.go'
       - '.github/workflows/docs.yml'
+      - '.github/workflows/_docs-build.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
 
-env:
-  # Hugo extended >= 0.146 is required by hugo-book v13.
-  HUGO_VERSION: 0.161.0
-  # Pinned to a release tag for reproducible builds; bump manually when upgrading the theme.
-  HUGO_BOOK_REF: v13
-
 jobs:
   build:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26.2"
-
-      - name: Install Hugo extended
-        run: |
-          set -euo pipefail
-          curl -sSL --fail \
-            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz" \
-            -o hugo.tar.gz
-          mkdir hugo-bin
-          tar -xzf hugo.tar.gz -C hugo-bin hugo
-          sudo mv hugo-bin/hugo /usr/local/bin/hugo
-          rm -rf hugo.tar.gz hugo-bin
-          hugo version
-
-      - name: Fetch hugo-book theme
-        run: |
-          set -euo pipefail
-          mkdir -p docs/themes
-          git clone --depth 1 --branch "${HUGO_BOOK_REF}" \
-            https://github.com/alex-shpak/hugo-book.git docs/themes/hugo-book
-          rm -rf docs/themes/hugo-book/.git
-
-      - name: Regenerate CLI reference
-        run: make docs-gen
-
-      - name: Verify CLI reference is up to date
-        run: |
-          if ! git diff --exit-code docs/content/docs/reference.md; then
-            echo "::error::docs/content/docs/reference.md is stale; run 'make docs-gen' and commit"
-            exit 1
-          fi
-
-      - name: Build site
-        working-directory: docs
-        run: hugo --minify
+    uses: ./.github/workflows/_docs-build.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
-      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -32,23 +31,6 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
-            docker:
-              - 'Dockerfile*'
-
-  hadolint:
-    needs: changes
-    if: needs.changes.outputs.docker == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - name: Lint Dockerfile with hadolint
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
-        with:
-          dockerfile: Dockerfile.goreleaser
-          failure-threshold: warning
 
   test:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      docker: ${{ steps.filter.outputs.docker }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -31,6 +32,23 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+            docker:
+              - 'Dockerfile*'
+
+  hadolint:
+    needs: changes
+    if: needs.changes.outputs.docker == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Lint Dockerfile with hadolint
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile.goreleaser
+          failure-threshold: warning
 
   test:
     needs: changes

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ diffyml compares YAML files and shows meaningful, structured differences — not
   - [Directory Comparison](#directory-comparison)
   - [Git Integration](#git-integration)
   - [AI Summary](#ai-summary)
+  - [Sensitive Value Masking](#sensitive-value-masking)
   - [Filtering](#filtering)
   - [Configuration File](#configuration-file)
   - [Custom Colors](#custom-colors)
@@ -185,6 +186,7 @@ export KUBECTL_EXTERNAL_DIFF="diffyml --omit-header --set-exit-code"
 - **Inline diff highlighting** — highlights only the changed parts within scalar values (version tags, IPs, ports) for quick scanning
 - **Custom colors** — configurable color palette for accessibility (colorblind-friendly)
 - **Configuration file** — project-level defaults via `.diffyml.yml` (all flags supported)
+- **Sensitive value masking** — opt-in redaction of Kubernetes Secret `data` / `stringData` and arbitrary paths; applies to every output format
 - ⭐ **AI-powered summaries** ⭐ — natural language summaries of changes via Anthropic API
 
 ## Usage
@@ -321,6 +323,37 @@ diffyml --summary --summary-model claude-sonnet-4-5-20250514 old.yaml new.yaml
 
 The summary is appended after the standard diff output. If the API call fails, a warning is printed to stderr and the diff output is preserved. The exit code is never affected by summary success or failure.
 
+### Sensitive Value Masking
+
+Masking is **opt-in**. When enabled, diffyml replaces the value of any matching diff with `***` before rendering — applies to every output format (including `json`, `json-patch`, and the `--summary` prompt). Diffs still show *that* a value changed, just not what the value was.
+
+```bash
+# Auto-mask data/stringData of Kubernetes Secret resources
+diffyml --mask-secrets secrets-old.yaml secrets-new.yaml
+
+# Mask additional paths (e.g., a ConfigMap field that holds an API key)
+diffyml --mask-path 'data.api_key' --mask-path 'data.db_url' old.yaml new.yaml
+
+# Regex variant — mask any field whose path matches
+diffyml --mask-path-regexp '(?i)password|token|secret' old.yaml new.yaml
+
+# Custom placeholder
+diffyml --mask-secrets --mask-placeholder '<REDACTED>' old.yaml new.yaml
+```
+
+Mask paths use the same dot-notation as `--filter` / `--exclude` (prefix match honored). The leading document index for multi-document files (`[0]`, `[1]`) is automatically stripped before matching.
+
+Configure defaults via `.diffyml.yml` so masking is always on for this repo:
+
+```yaml
+mask-secrets: true
+mask-path:
+  - "data.api_key"
+mask-path-regexp:
+  - "(?i)password"
+mask-placeholder: "***"
+```
+
 ### Filtering
 
 ```bash
@@ -414,6 +447,15 @@ Available environment variables: `DIFFYML_COLOR_ADDED`, `DIFFYML_COLOR_REMOVED`,
 | `--filter-regexp <pattern>` | Filter using regular expressions (repeatable) |
 | `--exclude-regexp <pattern>` | Exclude using regular expressions (repeatable) |
 | `--additional-identifier <field>` | Additional field for list item identification |
+
+**Sensitive Value Masking**
+
+| Flag | Description |
+|------|-------------|
+| `--mask-secrets` | Auto-mask `data` / `stringData` of Kubernetes Secret resources |
+| `--mask-path <path>` | Additional path to mask, dot-notation with prefix match (repeatable) |
+| `--mask-path-regexp <pattern>` | Additional path to mask, regex (repeatable) |
+| `--mask-placeholder <string>` | Placeholder for masked values (default `***`) |
 
 **Display**
 

--- a/doc/gen-cli-ref/main.go
+++ b/doc/gen-cli-ref/main.go
@@ -66,6 +66,7 @@ var categoryOrder = []string{
 	"Output",
 	"Comparison",
 	"Filtering",
+	"Masking",
 	"Display",
 	"Chroot",
 	"AI Summary",

--- a/docs/content/docs/config.md
+++ b/docs/content/docs/config.md
@@ -63,6 +63,12 @@ chroot-of-from: ""
 chroot-of-to: ""
 chroot-list-to-documents: false
 
+# Sensitive value masking (opt-in)
+mask-secrets: false
+mask-path: []
+mask-path-regexp: []
+mask-placeholder: "***"
+
 # AI Summary (requires ANTHROPIC_API_KEY environment variable)
 summary: false
 summary-model: "claude-haiku-4-5-20251001"
@@ -70,6 +76,8 @@ summary-model: "claude-haiku-4-5-20251001"
 # Exit code
 set-exit-code: false
 ```
+
+See [Sensitive Value Masking]({{< relref "/docs/masking" >}}) for usage.
 
 ## Custom colors
 

--- a/docs/content/docs/kubernetes.md
+++ b/docs/content/docs/kubernetes.md
@@ -37,6 +37,10 @@ diffyml --ignore-api-version manifests-v1.yaml manifests-v2.yaml
 diffyml --detect-kubernetes=false file1.yaml file2.yaml
 ```
 
+## Hiding Secret values
+
+`--mask-secrets` redacts the `data` / `stringData` fields of `Secret` resources before any output is produced — useful when diffs land in CI logs or PR comments. See [Sensitive Value Masking]({{< relref "/docs/masking" >}}).
+
 ## kubectl external diff
 
 See [CI Integration → kubectl external diff]({{< relref "/docs/ci#kubectl-external-diff" >}}) for the full setup.

--- a/docs/content/docs/masking.md
+++ b/docs/content/docs/masking.md
@@ -1,0 +1,72 @@
+---
+title: "Sensitive Value Masking"
+weight: 65
+---
+
+# Sensitive Value Masking
+
+Masking is **opt-in**. When enabled, diffyml replaces matching values with a placeholder (default `***`) before any output is rendered. The redacted value reaches every output format — `detailed`, `compact`, `brief`, `github`, `gitlab`, `gitea`, `json`, `json-patch` — and the AI summarizer prompt. Diffs still show *that* a value changed, just not what the value was.
+
+## Auto-mask Kubernetes Secret data
+
+`--mask-secrets` redacts the `data` and `stringData` fields of any document whose `kind` is `Secret`.
+
+```bash
+diffyml --mask-secrets secrets-old.yaml secrets-new.yaml
+```
+
+When an entire `Secret` document is added or removed, only its `data` / `stringData` subtrees are masked — `apiVersion`, `kind`, and `metadata` remain visible so the diff is still useful for review.
+
+## Mask additional paths
+
+`--mask-path` adds explicit dot-notation paths. Repeatable. Prefix matches are honored, so `data` masks every leaf under `data.*`.
+
+```bash
+diffyml \
+  --mask-path 'data.api_key' \
+  --mask-path 'data.db_url' \
+  configmap-old.yaml configmap-new.yaml
+```
+
+The leading document-index prefix for multi-document files (`[0]`, `[1]`) is automatically stripped before matching, so `--mask-path 'data.password'` works whether the input is single- or multi-doc.
+
+## Regex variant
+
+`--mask-path-regexp` matches the same stripped path with a Go regular expression. Repeatable.
+
+```bash
+diffyml --mask-path-regexp '(?i)password|token|secret' old.yaml new.yaml
+```
+
+## Custom placeholder
+
+```bash
+diffyml --mask-secrets --mask-placeholder '<REDACTED>' old.yaml new.yaml
+```
+
+## Configure defaults via `.diffyml.yml`
+
+Put masking on for every comparison in a repo:
+
+```yaml
+mask-secrets: true
+mask-path:
+  - "data.api_key"
+mask-path-regexp:
+  - "(?i)password"
+mask-placeholder: "***"
+```
+
+## Pipeline order
+
+```
+Compare → MaskDifferences → Filter → Format
+```
+
+Masking runs **before** filtering so you can still `--exclude` or `--filter` redacted diffs if you want them out of the report entirely.
+
+## What is *not* masked
+
+- **Order-change diffs** — their values are identifier lists for diagnostic purposes, not secrets.
+- **Path / key names** — only values are redacted. The path of a changed Secret field is still visible.
+- **Length information** — the placeholder is fixed-length regardless of the original value's size.

--- a/docs/content/docs/reference.md
+++ b/docs/content/docs/reference.md
@@ -43,6 +43,15 @@ diffyml [flags] <from> <to>
 | `--exclude-regexp` | `list` | — | exclude reports using regular expressions (repeatable) |
 | `--additional-identifier` | `list` | — | use additional identifier in named entry lists (repeatable) |
 
+## Masking
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--mask-secrets` | `bool` | — | auto-mask data/stringData of Kubernetes Secret resources |
+| `--mask-path` | `list` | — | additional path to mask (dot-notation, prefix match; repeatable) |
+| `--mask-path-regexp` | `list` | — | additional path to mask (regex; repeatable) |
+| `--mask-placeholder` | `string` | `***` | placeholder for masked values |
+
 ## Display
 
 | Flag | Type | Default | Description |

--- a/pkg/diffyml/cli/cli.go
+++ b/pkg/diffyml/cli/cli.go
@@ -52,6 +52,12 @@ type CLIConfig struct {
 	FilterRegexp  []string
 	ExcludeRegexp []string
 
+	// Sensitive value masking options
+	MaskSecrets     bool
+	MaskPaths       []string
+	MaskPathRegexp  []string
+	MaskPlaceholder string
+
 	// Chroot options
 	Chroot                string
 	ChrootFrom            string
@@ -90,6 +96,7 @@ func NewCLIConfig() *CLIConfig {
 		DetectKubernetes:      true,
 		DetectRenames:         true,
 		MultiLineContextLines: 4,
+		MaskPlaceholder:       diffyml.DefaultMaskPlaceholder,
 	}
 	cfg.initFlags()
 	return cfg
@@ -149,6 +156,18 @@ func (c *CLIConfig) initFlags() {
 		c.AdditionalIdentifiers = append(c.AdditionalIdentifiers, s)
 		return nil
 	})
+
+	// Sensitive value masking options
+	c.fs.BoolVar(&c.MaskSecrets, "mask-secrets", c.MaskSecrets, "auto-mask data/stringData of Kubernetes Secret resources")
+	c.fs.Func("mask-path", "additional path to mask (dot-notation, prefix match)", func(s string) error {
+		c.MaskPaths = append(c.MaskPaths, s)
+		return nil
+	})
+	c.fs.Func("mask-path-regexp", "additional path to mask (regex)", func(s string) error {
+		c.MaskPathRegexp = append(c.MaskPathRegexp, s)
+		return nil
+	})
+	c.fs.StringVar(&c.MaskPlaceholder, "mask-placeholder", c.MaskPlaceholder, "placeholder for masked values")
 
 	// Chroot options
 	c.fs.StringVar(&c.Chroot, "chroot", c.Chroot, "change the root level of the input file")
@@ -327,6 +346,16 @@ func (c *CLIConfig) ToFilterOptions() *diffyml.FilterOptions {
 	}
 }
 
+// ToMaskOptions converts CLI config to MaskOptions.
+func (c *CLIConfig) ToMaskOptions() diffyml.MaskOptions {
+	return diffyml.MaskOptions{
+		MaskSecrets:    c.MaskSecrets,
+		MaskPaths:      c.MaskPaths,
+		MaskPathRegexp: c.MaskPathRegexp,
+		Placeholder:    c.MaskPlaceholder,
+	}
+}
+
 // ToFormatOptions converts CLI config to FormatOptions.
 func (c *CLIConfig) ToFormatOptions() *diffyml.FormatOptions {
 	return &diffyml.FormatOptions{
@@ -371,6 +400,13 @@ func (c *CLIConfig) Usage() string {
 	sb.WriteString("      --filter-regexp strings         filter reports using regular expressions\n")
 	sb.WriteString("      --exclude-regexp strings        exclude reports using regular expressions\n")
 	sb.WriteString("      --additional-identifier string  use additional identifier in named entry lists\n")
+	sb.WriteString("\n")
+
+	// Sensitive value masking
+	sb.WriteString("      --mask-secrets                  auto-mask data/stringData of K8s Secrets\n")
+	sb.WriteString("      --mask-path strings             additional path to mask (dot-notation, prefix match)\n")
+	sb.WriteString("      --mask-path-regexp strings      additional path to mask (regex)\n")
+	sb.WriteString("      --mask-placeholder string       placeholder for masked values (default \"***\")\n")
 	sb.WriteString("\n")
 
 	// Display options
@@ -467,6 +503,9 @@ func (c *CLIConfig) Validate() error {
 		return err
 	}
 	if err := ValidateRegexPatterns(c.ExcludeRegexp, "exclude-regexp"); err != nil {
+		return err
+	}
+	if err := ValidateRegexPatterns(c.MaskPathRegexp, "mask-path-regexp"); err != nil {
 		return err
 	}
 
@@ -647,6 +686,17 @@ func runComparison(cfg *CLIConfig, rc *RunConfig, fromContent, toContent []byte,
 	diffs, err := diffyml.Compare(fromContent, toContent, compareOpts)
 	if err != nil {
 		err = fmt.Errorf("failed to compare files: %w", err)
+		if !cfg.GitExternalDiff {
+			fmt.Fprintf(rc.Stderr, "Error: %v\n", err)
+		}
+		return NewExitResult(ExitCodeError, err)
+	}
+
+	// Mask sensitive values (runs before filter so masked diffs can still be
+	// filtered if desired)
+	diffs, err = diffyml.MaskDifferences(diffs, cfg.ToMaskOptions())
+	if err != nil {
+		err = fmt.Errorf("mask error: %w", err)
 		if !cfg.GitExternalDiff {
 			fmt.Fprintf(rc.Stderr, "Error: %v\n", err)
 		}

--- a/pkg/diffyml/cli/config.go
+++ b/pkg/diffyml/cli/config.go
@@ -41,6 +41,12 @@ type FileConfig struct {
 	ExcludeRegexp         []string `yaml:"exclude-regexp"`
 	AdditionalIdentifiers []string `yaml:"additional-identifier"`
 
+	// Sensitive value masking options
+	MaskSecrets     *bool    `yaml:"mask-secrets"`
+	MaskPaths       []string `yaml:"mask-path"`
+	MaskPathRegexp  []string `yaml:"mask-path-regexp"`
+	MaskPlaceholder *string  `yaml:"mask-placeholder"`
+
 	// Display options
 	OmitHeader            *bool `yaml:"omit-header"`
 	UseGoPatchStyle       *bool `yaml:"use-go-patch-style"`
@@ -187,6 +193,20 @@ func (c *CLIConfig) applyFileConfig(fc *FileConfig, cliSet map[string]bool) {
 	}
 	if len(fc.AdditionalIdentifiers) > 0 && notSet("additional-identifier") {
 		c.AdditionalIdentifiers = fc.AdditionalIdentifiers
+	}
+
+	// Sensitive value masking options
+	if fc.MaskSecrets != nil && notSet("mask-secrets") {
+		c.MaskSecrets = *fc.MaskSecrets
+	}
+	if len(fc.MaskPaths) > 0 && notSet("mask-path") {
+		c.MaskPaths = fc.MaskPaths
+	}
+	if len(fc.MaskPathRegexp) > 0 && notSet("mask-path-regexp") {
+		c.MaskPathRegexp = fc.MaskPathRegexp
+	}
+	if fc.MaskPlaceholder != nil && notSet("mask-placeholder") {
+		c.MaskPlaceholder = *fc.MaskPlaceholder
 	}
 
 	// Display options

--- a/pkg/diffyml/cli/config_test.go
+++ b/pkg/diffyml/cli/config_test.go
@@ -702,6 +702,25 @@ func TestApplyFileConfig_EmptySlicesDoNotOverride(t *testing.T) {
 	}
 }
 
+func TestApplyFileConfig_EmptyMaskSlicesDoNotOverride(t *testing.T) {
+	cfg := NewCLIConfig()
+	cfg.MaskPaths = []string{"existing-mask-path"}
+	cfg.MaskPathRegexp = []string{"existing-mask-regexp"}
+
+	fc := &FileConfig{
+		MaskPaths:      []string{},
+		MaskPathRegexp: []string{},
+	}
+	cfg.applyFileConfig(fc, map[string]bool{})
+
+	if len(cfg.MaskPaths) != 1 || cfg.MaskPaths[0] != "existing-mask-path" {
+		t.Errorf("expected MaskPaths=['existing-mask-path'], got %v", cfg.MaskPaths)
+	}
+	if len(cfg.MaskPathRegexp) != 1 || cfg.MaskPathRegexp[0] != "existing-mask-regexp" {
+		t.Errorf("expected MaskPathRegexp=['existing-mask-regexp'], got %v", cfg.MaskPathRegexp)
+	}
+}
+
 // --- Integration tests (through ParseArgs) ---
 
 func TestParseArgs_WithConfigFile(t *testing.T) {

--- a/pkg/diffyml/cli/flag_metadata.go
+++ b/pkg/diffyml/cli/flag_metadata.go
@@ -45,6 +45,12 @@ func FlagDocs() []FlagDoc {
 		{Long: "exclude-regexp", Type: "list", Category: "Filtering", Usage: "exclude reports using regular expressions (repeatable)"},
 		{Long: "additional-identifier", Type: "list", Category: "Filtering", Usage: "use additional identifier in named entry lists (repeatable)"},
 
+		// Sensitive value masking
+		{Long: "mask-secrets", Type: "bool", Category: "Masking", Usage: "auto-mask data/stringData of Kubernetes Secret resources"},
+		{Long: "mask-path", Type: "list", Category: "Masking", Usage: "additional path to mask (dot-notation, prefix match; repeatable)"},
+		{Long: "mask-path-regexp", Type: "list", Category: "Masking", Usage: "additional path to mask (regex; repeatable)"},
+		{Long: "mask-placeholder", Type: "string", Default: "***", Category: "Masking", Usage: "placeholder for masked values"},
+
 		// Display
 		{Long: "omit-header", Short: "b", Type: "bool", Category: "Display", Usage: "omit the diffyml summary header"},
 		{Long: "use-go-patch-style", Short: "g", Type: "bool", Category: "Display", Usage: "use Go-Patch style paths in outputs"},

--- a/pkg/diffyml/diffyml.go
+++ b/pkg/diffyml/diffyml.go
@@ -37,6 +37,11 @@ type Difference struct {
 	// DocumentName is a human-readable label for the document (e.g., K8s resource display name).
 	// Empty for non-K8s documents or when detection is disabled.
 	DocumentName string
+	// DocumentKind is the Kubernetes "kind" of the document (e.g., "Secret", "ConfigMap").
+	// Empty for non-K8s documents or when detection is disabled. Used by sensitive value
+	// masking to identify Secret resources without parsing DocumentName, since apiVersion
+	// can itself contain "/" (e.g., "apps/v1").
+	DocumentKind string
 }
 
 // Options configures the comparison behavior.

--- a/pkg/diffyml/kubernetes.go
+++ b/pkg/diffyml/kubernetes.go
@@ -146,6 +146,16 @@ func K8sResourceDisplayName(doc any) string {
 	return fmt.Sprintf("%s/%s/%s", f.apiVersion, f.kind, f.name)
 }
 
+// K8sResourceKind returns the "kind" field of a Kubernetes resource document.
+// Returns empty string if the document is not a valid K8s resource.
+func K8sResourceKind(doc any) string {
+	f, ok := k8sExtractFields(doc)
+	if !ok {
+		return ""
+	}
+	return f.kind
+}
+
 // IdentifierWithAdditional gets an identifier value from a map,
 // checking default fields (name, id) and any additional specified fields.
 func IdentifierWithAdditional(m map[string]any, additionalIdentifiers []string) any {
@@ -326,9 +336,11 @@ func compareMatchedK8sDocs(matched map[int]int, from, to []any, opts *Options, u
 
 		nodeDiffs := compareNodes(pathPrefix, fromDoc, toDoc, opts)
 		docName := K8sResourceDisplayName(toDoc)
+		docKind := K8sResourceKind(toDoc)
 		for i := range nodeDiffs {
 			nodeDiffs[i].DocumentIndex = docIdx
 			nodeDiffs[i].DocumentName = docName
+			nodeDiffs[i].DocumentKind = docKind
 		}
 		diffs = append(diffs, nodeDiffs...)
 	}
@@ -371,6 +383,7 @@ func compareK8sDocs(from, to []any, opts *Options) []Difference {
 			To:            nil,
 			DocumentIndex: fromIdx,
 			DocumentName:  K8sResourceDisplayName(from[fromIdx]),
+			DocumentKind:  K8sResourceKind(from[fromIdx]),
 		})
 	}
 
@@ -387,6 +400,7 @@ func compareK8sDocs(from, to []any, opts *Options) []Difference {
 			To:            to[toIdx],
 			DocumentIndex: toIdx,
 			DocumentName:  K8sResourceDisplayName(to[toIdx]),
+			DocumentKind:  K8sResourceKind(to[toIdx]),
 		})
 	}
 

--- a/pkg/diffyml/kubernetes.go
+++ b/pkg/diffyml/kubernetes.go
@@ -140,10 +140,7 @@ func K8sResourceDisplayName(doc any) string {
 	if !ok {
 		return ""
 	}
-	if f.namespace != "" {
-		return fmt.Sprintf("%s/%s/%s/%s", f.apiVersion, f.kind, f.namespace, f.name)
-	}
-	return fmt.Sprintf("%s/%s/%s", f.apiVersion, f.kind, f.name)
+	return f.displayName()
 }
 
 // K8sResourceKind returns the "kind" field of a Kubernetes resource document.
@@ -154,6 +151,14 @@ func K8sResourceKind(doc any) string {
 		return ""
 	}
 	return f.kind
+}
+
+// displayName renders k8sResourceFields in the same format as K8sResourceDisplayName.
+func (f k8sResourceFields) displayName() string {
+	if f.namespace != "" {
+		return fmt.Sprintf("%s/%s/%s/%s", f.apiVersion, f.kind, f.namespace, f.name)
+	}
+	return fmt.Sprintf("%s/%s/%s", f.apiVersion, f.kind, f.name)
 }
 
 // IdentifierWithAdditional gets an identifier value from a map,
@@ -335,8 +340,11 @@ func compareMatchedK8sDocs(matched map[int]int, from, to []any, opts *Options, u
 		}
 
 		nodeDiffs := compareNodes(pathPrefix, fromDoc, toDoc, opts)
-		docName := K8sResourceDisplayName(toDoc)
-		docKind := K8sResourceKind(toDoc)
+		var docName, docKind string
+		if f, ok := k8sExtractFields(toDoc); ok {
+			docName = f.displayName()
+			docKind = f.kind
+		}
 		for i := range nodeDiffs {
 			nodeDiffs[i].DocumentIndex = docIdx
 			nodeDiffs[i].DocumentName = docName
@@ -376,14 +384,19 @@ func compareK8sDocs(from, to []any, opts *Options) []Difference {
 			continue
 		}
 		pathPrefix := DiffPath{fmt.Sprintf("[%d]", fromIdx)}
+		var docName, docKind string
+		if f, ok := k8sExtractFields(from[fromIdx]); ok {
+			docName = f.displayName()
+			docKind = f.kind
+		}
 		diffs = append(diffs, Difference{
 			Path:          pathPrefix,
 			Type:          DiffRemoved,
 			From:          from[fromIdx],
 			To:            nil,
 			DocumentIndex: fromIdx,
-			DocumentName:  K8sResourceDisplayName(from[fromIdx]),
-			DocumentKind:  K8sResourceKind(from[fromIdx]),
+			DocumentName:  docName,
+			DocumentKind:  docKind,
 		})
 	}
 
@@ -393,14 +406,19 @@ func compareK8sDocs(from, to []any, opts *Options) []Difference {
 			continue
 		}
 		pathPrefix := DiffPath{fmt.Sprintf("[%d]", toIdx)}
+		var docName, docKind string
+		if f, ok := k8sExtractFields(to[toIdx]); ok {
+			docName = f.displayName()
+			docKind = f.kind
+		}
 		diffs = append(diffs, Difference{
 			Path:          pathPrefix,
 			Type:          DiffAdded,
 			From:          nil,
 			To:            to[toIdx],
 			DocumentIndex: toIdx,
-			DocumentName:  K8sResourceDisplayName(to[toIdx]),
-			DocumentKind:  K8sResourceKind(to[toIdx]),
+			DocumentName:  docName,
+			DocumentKind:  docKind,
 		})
 	}
 

--- a/pkg/diffyml/kubernetes_test.go
+++ b/pkg/diffyml/kubernetes_test.go
@@ -1446,6 +1446,20 @@ func TestK8sResourceDisplayName_NotK8s(t *testing.T) {
 	}
 }
 
+func TestK8sResourceKind(t *testing.T) {
+	k8s := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]any{"name": "foo"},
+	}
+	if got := K8sResourceKind(k8s); got != "Secret" {
+		t.Errorf("expected 'Secret', got %q", got)
+	}
+	if got := K8sResourceKind(map[string]any{"key": "value"}); got != "" {
+		t.Errorf("expected empty string for non-K8s doc, got %q", got)
+	}
+}
+
 func TestK8sResourceDisplayName_WithNamespace(t *testing.T) {
 	doc := map[string]any{
 		"apiVersion": "apps/v1",

--- a/pkg/diffyml/mask.go
+++ b/pkg/diffyml/mask.go
@@ -87,11 +87,9 @@ const (
 var secretMaskedKeys = map[string]bool{"data": true, "stringData": true}
 
 func maskScopeFor(d Difference, opts MaskOptions, regex []*regexp.Regexp) maskScope {
-	if len(opts.MaskPaths) > 0 || len(regex) > 0 {
-		pathStr := pathWithoutDocIndex(d.Path)
-		if matchesAnyPath(pathStr, opts.MaskPaths) || matchesAnyRegex(pathStr, regex) {
-			return maskScopeAll
-		}
+	pathStr := pathWithoutDocIndex(d.Path)
+	if matchesAnyPath(pathStr, opts.MaskPaths) || matchesAnyRegex(pathStr, regex) {
+		return maskScopeAll
 	}
 	if !opts.MaskSecrets || d.DocumentKind != "Secret" {
 		return maskScopeNone

--- a/pkg/diffyml/mask.go
+++ b/pkg/diffyml/mask.go
@@ -1,0 +1,207 @@
+// mask.go - Sensitive value masking for diff output.
+//
+// Redacts values in [Difference.From] and [Difference.To] before they reach any
+// formatter (including JSON, JSON-Patch, and the AI summarizer). When MaskSecrets
+// is enabled, values under "data" and "stringData" of Kubernetes Secret resources
+// are auto-masked. Users can declare additional paths via MaskPaths and
+// MaskPathRegexp.
+//
+// Masking runs after Compare and before filtering, so a redacted diff still
+// appears in the report — only the value is replaced with the placeholder.
+package diffyml
+
+import "regexp"
+
+// DefaultMaskPlaceholder is the value substituted into masked diffs when
+// MaskOptions.Placeholder is empty.
+const DefaultMaskPlaceholder = "***"
+
+// MaskOptions configures sensitive value masking.
+type MaskOptions struct {
+	// MaskSecrets enables auto-masking of "data" and "stringData" fields on
+	// documents whose [Difference.DocumentKind] equals "Secret".
+	MaskSecrets bool
+	// MaskPaths is a list of dot-notation paths whose matching diffs are masked.
+	// Paths are matched against the diff path with any leading document-index
+	// prefix (e.g., "[0]") stripped. Prefix matches are honored ("data" matches
+	// "data.password").
+	MaskPaths []string
+	// MaskPathRegexp is a list of regex patterns matched against the same
+	// stripped path used by MaskPaths.
+	MaskPathRegexp []string
+	// Placeholder is the value substituted for masked scalars.
+	// Defaults to [DefaultMaskPlaceholder] when empty.
+	Placeholder string
+}
+
+// MaskDifferences redacts sensitive values in the given diffs in-place and
+// returns the same slice. Order-change diffs ([DiffOrderChanged]) are never
+// masked (their values are identifier lists, not secrets).
+//
+// Returns an error only if a regex pattern in opts.MaskPathRegexp fails to
+// compile.
+func MaskDifferences(diffs []Difference, opts MaskOptions) ([]Difference, error) {
+	if !opts.MaskSecrets && len(opts.MaskPaths) == 0 && len(opts.MaskPathRegexp) == 0 {
+		return diffs, nil
+	}
+
+	placeholder := opts.Placeholder
+	if placeholder == "" {
+		placeholder = DefaultMaskPlaceholder
+	}
+
+	regex, err := compileRegexPatterns(opts.MaskPathRegexp)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range diffs {
+		if diffs[i].Type == DiffOrderChanged {
+			continue
+		}
+		switch maskScopeFor(diffs[i], opts, regex) {
+		case maskScopeAll:
+			diffs[i].From = maskValueRecursive(diffs[i].From, placeholder)
+			diffs[i].To = maskValueRecursive(diffs[i].To, placeholder)
+		case maskScopeSecretFields:
+			diffs[i].From = maskSecretSubtrees(diffs[i].From, placeholder)
+			diffs[i].To = maskSecretSubtrees(diffs[i].To, placeholder)
+		}
+	}
+	return diffs, nil
+}
+
+type maskScope int
+
+const (
+	maskScopeNone maskScope = iota
+	// maskScopeAll redacts every leaf in From/To.
+	maskScopeAll
+	// maskScopeSecretFields redacts only the "data" and "stringData" subtrees
+	// within From/To. Used for whole-document Secret add/remove diffs so other
+	// fields (apiVersion, metadata) remain visible.
+	maskScopeSecretFields
+)
+
+// secretMaskedKeys are the top-level Secret fields whose values are auto-masked.
+var secretMaskedKeys = map[string]bool{"data": true, "stringData": true}
+
+func maskScopeFor(d Difference, opts MaskOptions, regex []*regexp.Regexp) maskScope {
+	pathStr := pathWithoutDocIndex(d.Path)
+	if matchesAnyPath(pathStr, opts.MaskPaths) || matchesAnyRegex(pathStr, regex) {
+		return maskScopeAll
+	}
+	if !opts.MaskSecrets || d.DocumentKind != "Secret" {
+		return maskScopeNone
+	}
+	first, hasField := firstFieldAfterDocIndex(d.Path)
+	if hasField && secretMaskedKeys[first] {
+		return maskScopeAll
+	}
+	if isWholeDocDiff(d.Path) {
+		return maskScopeSecretFields
+	}
+	return maskScopeNone
+}
+
+// maskValueRecursive returns a copy of v with every scalar leaf replaced by
+// placeholder. Maps and lists are reconstructed; map keys and list lengths are
+// preserved. nil values pass through unchanged.
+func maskValueRecursive(v any, placeholder string) any {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case *OrderedMap:
+		out := &OrderedMap{
+			Keys:   append([]string(nil), val.Keys...),
+			Values: make(map[string]any, len(val.Values)),
+		}
+		for k, sub := range val.Values {
+			out.Values[k] = maskValueRecursive(sub, placeholder)
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, sub := range val {
+			out[k] = maskValueRecursive(sub, placeholder)
+		}
+		return out
+	case []any:
+		out := make([]any, len(val))
+		for i, sub := range val {
+			out[i] = maskValueRecursive(sub, placeholder)
+		}
+		return out
+	default:
+		return placeholder
+	}
+}
+
+// maskSecretSubtrees returns a shallow copy of v in which only the values under
+// keys in [secretMaskedKeys] are recursively masked. Other branches are
+// preserved by reference. Used when an entire Secret document is added or
+// removed.
+func maskSecretSubtrees(v any, placeholder string) any {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case *OrderedMap:
+		out := &OrderedMap{
+			Keys:   append([]string(nil), val.Keys...),
+			Values: make(map[string]any, len(val.Values)),
+		}
+		for k, sub := range val.Values {
+			if secretMaskedKeys[k] {
+				out.Values[k] = maskValueRecursive(sub, placeholder)
+			} else {
+				out.Values[k] = sub
+			}
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(val))
+		for k, sub := range val {
+			if secretMaskedKeys[k] {
+				out[k] = maskValueRecursive(sub, placeholder)
+			} else {
+				out[k] = sub
+			}
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+// pathWithoutDocIndex renders the diff path without a leading document-index
+// segment like "[0]". The result is what users specify with --mask-path.
+func pathWithoutDocIndex(p DiffPath) string {
+	if len(p) > 0 && len(p[0]) > 0 && p[0][0] == '[' {
+		return p[1:].String()
+	}
+	return p.String()
+}
+
+// firstFieldAfterDocIndex returns the first non-document-index segment of the
+// path, e.g. "data" for both "data.password" and "[0].data.password". Returns
+// ("", false) if no field segment exists.
+func firstFieldAfterDocIndex(p DiffPath) (string, bool) {
+	if len(p) == 0 {
+		return "", false
+	}
+	if len(p[0]) > 0 && p[0][0] == '[' {
+		if len(p) < 2 {
+			return "", false
+		}
+		return p[1], true
+	}
+	return p[0], true
+}
+
+// isWholeDocDiff reports whether the path refers to a whole document
+// (e.g., "[0]") rather than a field within one.
+func isWholeDocDiff(p DiffPath) bool {
+	return len(p) == 1 && len(p[0]) > 0 && p[0][0] == '['
+}

--- a/pkg/diffyml/mask.go
+++ b/pkg/diffyml/mask.go
@@ -87,9 +87,11 @@ const (
 var secretMaskedKeys = map[string]bool{"data": true, "stringData": true}
 
 func maskScopeFor(d Difference, opts MaskOptions, regex []*regexp.Regexp) maskScope {
-	pathStr := pathWithoutDocIndex(d.Path)
-	if matchesAnyPath(pathStr, opts.MaskPaths) || matchesAnyRegex(pathStr, regex) {
-		return maskScopeAll
+	if len(opts.MaskPaths) > 0 || len(regex) > 0 {
+		pathStr := pathWithoutDocIndex(d.Path)
+		if matchesAnyPath(pathStr, opts.MaskPaths) || matchesAnyRegex(pathStr, regex) {
+			return maskScopeAll
+		}
 	}
 	if !opts.MaskSecrets || d.DocumentKind != "Secret" {
 		return maskScopeNone
@@ -178,7 +180,7 @@ func maskSecretSubtrees(v any, placeholder string) any {
 // pathWithoutDocIndex renders the diff path without a leading document-index
 // segment like "[0]". The result is what users specify with --mask-path.
 func pathWithoutDocIndex(p DiffPath) string {
-	if len(p) > 0 && len(p[0]) > 0 && p[0][0] == '[' {
+	if _, ok := p.DocIndex(); ok {
 		return p[1:].String()
 	}
 	return p.String()
@@ -188,14 +190,14 @@ func pathWithoutDocIndex(p DiffPath) string {
 // path, e.g. "data" for both "data.password" and "[0].data.password". Returns
 // ("", false) if no field segment exists.
 func firstFieldAfterDocIndex(p DiffPath) (string, bool) {
-	if len(p) == 0 {
-		return "", false
-	}
-	if len(p[0]) > 0 && p[0][0] == '[' {
+	if _, ok := p.DocIndex(); ok {
 		if len(p) < 2 {
 			return "", false
 		}
 		return p[1], true
+	}
+	if len(p) == 0 {
+		return "", false
 	}
 	return p[0], true
 }
@@ -203,5 +205,5 @@ func firstFieldAfterDocIndex(p DiffPath) (string, bool) {
 // isWholeDocDiff reports whether the path refers to a whole document
 // (e.g., "[0]") rather than a field within one.
 func isWholeDocDiff(p DiffPath) bool {
-	return len(p) == 1 && len(p[0]) > 0 && p[0][0] == '['
+	return p.IsBareDocIndex()
 }

--- a/pkg/diffyml/mask_test.go
+++ b/pkg/diffyml/mask_test.go
@@ -294,6 +294,7 @@ func TestFirstFieldAfterDocIndex(t *testing.T) {
 	}{
 		{DiffPath{"data", "x"}, "data", true},
 		{DiffPath{"[0]", "data", "x"}, "data", true},
+		{DiffPath{"[0]", "data"}, "data", true},
 		{DiffPath{"[0]"}, "", false},
 		{DiffPath{}, "", false},
 	}

--- a/pkg/diffyml/mask_test.go
+++ b/pkg/diffyml/mask_test.go
@@ -1,0 +1,289 @@
+package diffyml
+
+import (
+	"testing"
+)
+
+func TestMaskDifferences_NoOptions_ReturnsUnchanged(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"data", "password"}, Type: DiffModified, From: "old", To: "new", DocumentKind: "Secret"},
+	}
+	got, err := MaskDifferences(diffs, MaskOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got[0].From != "old" || got[0].To != "new" {
+		t.Errorf("expected values unchanged, got from=%v to=%v", got[0].From, got[0].To)
+	}
+}
+
+func TestMaskDifferences_AutoMaskSecretData(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"data", "password"}, Type: DiffModified, From: "aGVsbG8=", To: "d29ybGQ=", DocumentKind: "Secret"},
+		{Path: DiffPath{"metadata", "name"}, Type: DiffModified, From: "old", To: "new", DocumentKind: "Secret"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true})
+	if got[0].From != "***" || got[0].To != "***" {
+		t.Errorf("data.password should be masked, got from=%v to=%v", got[0].From, got[0].To)
+	}
+	if got[1].From != "old" || got[1].To != "new" {
+		t.Errorf("metadata.name should NOT be masked, got from=%v to=%v", got[1].From, got[1].To)
+	}
+}
+
+func TestMaskDifferences_AutoMaskStringData(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"stringData", "token"}, Type: DiffModified, From: "abc", To: "xyz", DocumentKind: "Secret"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true})
+	if got[0].From != "***" || got[0].To != "***" {
+		t.Errorf("stringData should be masked, got from=%v to=%v", got[0].From, got[0].To)
+	}
+}
+
+func TestMaskDifferences_DoesNotMaskNonSecretKinds(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"data", "config"}, Type: DiffModified, From: "old", To: "new", DocumentKind: "ConfigMap"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true})
+	if got[0].From != "old" {
+		t.Errorf("ConfigMap data should NOT be auto-masked, got %v", got[0].From)
+	}
+}
+
+func TestMaskDifferences_HandlesDocIndexPrefix(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"[1]", "data", "key"}, Type: DiffModified, From: "a", To: "b", DocumentKind: "Secret"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true})
+	if got[0].From != "***" {
+		t.Errorf("[1].data.key should be masked, got %v", got[0].From)
+	}
+}
+
+func TestMaskDifferences_CustomMaskPath(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"data", "api_key"}, Type: DiffModified, From: "old", To: "new", DocumentKind: "ConfigMap"},
+		{Path: DiffPath{"data", "log_level"}, Type: DiffModified, From: "info", To: "debug", DocumentKind: "ConfigMap"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskPaths: []string{"data.api_key"}})
+	if got[0].From != "***" {
+		t.Errorf("data.api_key should be masked, got %v", got[0].From)
+	}
+	if got[1].From != "info" {
+		t.Errorf("data.log_level should NOT be masked, got %v", got[1].From)
+	}
+}
+
+func TestMaskDifferences_CustomMaskPath_PrefixMatch(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"secrets", "db", "password"}, Type: DiffModified, From: "a", To: "b"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskPaths: []string{"secrets"}})
+	if got[0].From != "***" {
+		t.Errorf("secrets.db.password should be masked via prefix, got %v", got[0].From)
+	}
+}
+
+func TestMaskDifferences_RegexPath(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"config", "DB_PASSWORD"}, Type: DiffModified, From: "a", To: "b"},
+		{Path: DiffPath{"config", "log_level"}, Type: DiffModified, From: "info", To: "debug"},
+	}
+	got, err := MaskDifferences(diffs, MaskOptions{MaskPathRegexp: []string{`(?i)password`}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got[0].From != "***" {
+		t.Errorf("DB_PASSWORD should be masked by regex, got %v", got[0].From)
+	}
+	if got[1].From != "info" {
+		t.Errorf("log_level should not match password regex, got %v", got[1].From)
+	}
+}
+
+func TestMaskDifferences_InvalidRegex_ReturnsError(t *testing.T) {
+	_, err := MaskDifferences(nil, MaskOptions{MaskPathRegexp: []string{"["}})
+	if err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+}
+
+func TestMaskDifferences_CustomPlaceholder(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"data", "x"}, Type: DiffModified, From: "a", To: "b", DocumentKind: "Secret"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true, Placeholder: "<redacted>"})
+	if got[0].From != "<redacted>" {
+		t.Errorf("expected custom placeholder, got %v", got[0].From)
+	}
+}
+
+func TestMaskDifferences_OrderChangedDiffs_NotMasked(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"(document)"}, Type: DiffOrderChanged, From: []any{"a", "b"}, To: []any{"b", "a"}, DocumentKind: "Secret"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true})
+	fromList, ok := got[0].From.([]any)
+	if !ok || len(fromList) != 2 || fromList[0] != "a" {
+		t.Errorf("order-change identifiers should not be masked, got %v", got[0].From)
+	}
+}
+
+func TestMaskDifferences_PreservesDiffCount(t *testing.T) {
+	diffs := []Difference{
+		{Path: DiffPath{"data", "a"}, Type: DiffModified, From: "1", To: "2", DocumentKind: "Secret"},
+		{Path: DiffPath{"data", "b"}, Type: DiffModified, From: "3", To: "4", DocumentKind: "Secret"},
+		{Path: DiffPath{"metadata", "labels", "app"}, Type: DiffAdded, From: nil, To: "x", DocumentKind: "Secret"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true})
+	if len(got) != 3 {
+		t.Errorf("masking must not change diff count, got %d", len(got))
+	}
+}
+
+func TestMaskDifferences_WholeSecretAdded_MasksDataSubtree(t *testing.T) {
+	secretDoc := &OrderedMap{
+		Keys: []string{"apiVersion", "kind", "metadata", "data"},
+		Values: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata":   &OrderedMap{Keys: []string{"name"}, Values: map[string]any{"name": "foo"}},
+			"data":       &OrderedMap{Keys: []string{"password"}, Values: map[string]any{"password": "aGVsbG8="}},
+		},
+	}
+	diffs := []Difference{
+		{Path: DiffPath{"[0]"}, Type: DiffAdded, From: nil, To: secretDoc, DocumentKind: "Secret"},
+	}
+	got, _ := MaskDifferences(diffs, MaskOptions{MaskSecrets: true})
+	root, ok := got[0].To.(*OrderedMap)
+	if !ok {
+		t.Fatalf("expected OrderedMap, got %T", got[0].To)
+	}
+	if root.Values["apiVersion"] != "v1" {
+		t.Errorf("apiVersion should be preserved, got %v", root.Values["apiVersion"])
+	}
+	if root.Values["kind"] != "Secret" {
+		t.Errorf("kind should be preserved, got %v", root.Values["kind"])
+	}
+	dataMap, ok := root.Values["data"].(*OrderedMap)
+	if !ok {
+		t.Fatalf("expected data to be OrderedMap, got %T", root.Values["data"])
+	}
+	if dataMap.Values["password"] != "***" {
+		t.Errorf("data.password should be masked, got %v", dataMap.Values["password"])
+	}
+}
+
+func TestMaskValueRecursive_Scalar(t *testing.T) {
+	if got := maskValueRecursive("hello", "X"); got != "X" {
+		t.Errorf("expected 'X', got %v", got)
+	}
+	if got := maskValueRecursive(42, "X"); got != "X" {
+		t.Errorf("expected 'X' for int, got %v", got)
+	}
+	if got := maskValueRecursive(nil, "X"); got != nil {
+		t.Errorf("nil should pass through, got %v", got)
+	}
+}
+
+func TestMaskValueRecursive_OrderedMap_PreservesKeys(t *testing.T) {
+	in := &OrderedMap{
+		Keys:   []string{"a", "b"},
+		Values: map[string]any{"a": "1", "b": "2"},
+	}
+	out, ok := maskValueRecursive(in, "X").(*OrderedMap)
+	if !ok {
+		t.Fatalf("expected OrderedMap")
+	}
+	if len(out.Keys) != 2 || out.Keys[0] != "a" || out.Keys[1] != "b" {
+		t.Errorf("key order not preserved: %v", out.Keys)
+	}
+	if out.Values["a"] != "X" || out.Values["b"] != "X" {
+		t.Errorf("values not masked: %v", out.Values)
+	}
+}
+
+func TestMaskValueRecursive_NestedStructure(t *testing.T) {
+	in := &OrderedMap{
+		Keys: []string{"list", "map"},
+		Values: map[string]any{
+			"list": []any{"a", "b", &OrderedMap{Keys: []string{"x"}, Values: map[string]any{"x": "y"}}},
+			"map":  map[string]any{"k": "v"},
+		},
+	}
+	out := maskValueRecursive(in, "X").(*OrderedMap)
+	list := out.Values["list"].([]any)
+	if list[0] != "X" || list[1] != "X" {
+		t.Errorf("list scalars not masked: %v", list)
+	}
+	nested := list[2].(*OrderedMap)
+	if nested.Values["x"] != "X" {
+		t.Errorf("nested OrderedMap not masked: %v", nested.Values)
+	}
+	plainMap := out.Values["map"].(map[string]any)
+	if plainMap["k"] != "X" {
+		t.Errorf("plain map not masked: %v", plainMap)
+	}
+}
+
+func TestMaskValueRecursive_DoesNotMutateInput(t *testing.T) {
+	in := &OrderedMap{Keys: []string{"a"}, Values: map[string]any{"a": "original"}}
+	_ = maskValueRecursive(in, "X")
+	if in.Values["a"] != "original" {
+		t.Errorf("input was mutated: %v", in.Values["a"])
+	}
+}
+
+func TestPathWithoutDocIndex(t *testing.T) {
+	cases := []struct {
+		in   DiffPath
+		want string
+	}{
+		{DiffPath{"data", "x"}, "data.x"},
+		{DiffPath{"[0]", "data", "x"}, "data.x"},
+		{DiffPath{"[0]"}, ""},
+		{DiffPath{}, ""},
+	}
+	for _, c := range cases {
+		if got := pathWithoutDocIndex(c.in); got != c.want {
+			t.Errorf("pathWithoutDocIndex(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFirstFieldAfterDocIndex(t *testing.T) {
+	cases := []struct {
+		in     DiffPath
+		want   string
+		wantOk bool
+	}{
+		{DiffPath{"data", "x"}, "data", true},
+		{DiffPath{"[0]", "data", "x"}, "data", true},
+		{DiffPath{"[0]"}, "", false},
+		{DiffPath{}, "", false},
+	}
+	for _, c := range cases {
+		got, ok := firstFieldAfterDocIndex(c.in)
+		if got != c.want || ok != c.wantOk {
+			t.Errorf("firstFieldAfterDocIndex(%v) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.wantOk)
+		}
+	}
+}
+
+func TestIsWholeDocDiff(t *testing.T) {
+	cases := []struct {
+		in   DiffPath
+		want bool
+	}{
+		{DiffPath{"[0]"}, true},
+		{DiffPath{"[0]", "data"}, false},
+		{DiffPath{"data"}, false},
+		{DiffPath{}, false},
+	}
+	for _, c := range cases {
+		if got := isWholeDocDiff(c.in); got != c.want {
+			t.Errorf("isWholeDocDiff(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/pkg/diffyml/mask_test.go
+++ b/pkg/diffyml/mask_test.go
@@ -227,6 +227,40 @@ func TestMaskValueRecursive_NestedStructure(t *testing.T) {
 	}
 }
 
+func TestMaskSecretSubtrees_PlainMap(t *testing.T) {
+	in := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"data":       map[string]any{"password": "aGVsbG8="},
+	}
+	out, ok := maskSecretSubtrees(in, "***").(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", out)
+	}
+	if out["apiVersion"] != "v1" || out["kind"] != "Secret" {
+		t.Errorf("non-data fields should be preserved, got %v", out)
+	}
+	dataMap, ok := out["data"].(map[string]any)
+	if !ok || dataMap["password"] != "***" {
+		t.Errorf("data.password should be masked, got %v", out["data"])
+	}
+}
+
+func TestMaskSecretSubtrees_NonMapValue_Unchanged(t *testing.T) {
+	if got := maskSecretSubtrees("scalar", "***"); got != "scalar" {
+		t.Errorf("non-map value should pass through, got %v", got)
+	}
+	if got := maskSecretSubtrees([]any{"a", "b"}, "***"); got == nil {
+		t.Errorf("non-map value should pass through, got nil")
+	}
+}
+
+func TestMaskSecretSubtrees_Nil(t *testing.T) {
+	if got := maskSecretSubtrees(nil, "***"); got != nil {
+		t.Errorf("nil should pass through, got %v", got)
+	}
+}
+
 func TestMaskValueRecursive_DoesNotMutateInput(t *testing.T) {
 	in := &OrderedMap{Keys: []string{"a"}, Values: map[string]any{"a": "original"}}
 	_ = maskValueRecursive(in, "X")

--- a/testdata/fixtures/112-mask-secret-explicit/expected_output.txt
+++ b/testdata/fixtures/112-mask-secret-explicit/expected_output.txt
@@ -1,0 +1,12 @@
+Found two differences
+
+data.password  (v1/Secret/app-secret)
+  ± value change
+    - ***
+    + ***
+
+data.api_key  (v1/Secret/app-secret)
+  ± value change
+    - ***
+    + ***
+

--- a/testdata/fixtures/112-mask-secret-explicit/file1.yaml
+++ b/testdata/fixtures/112-mask-secret-explicit/file1.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+data:
+  password: aGVsbG8=
+  api_key: c2VjcmV0

--- a/testdata/fixtures/112-mask-secret-explicit/file2.yaml
+++ b/testdata/fixtures/112-mask-secret-explicit/file2.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+data:
+  password: d29ybGQ=
+  api_key: bmV3LXNlY3JldA==

--- a/testdata/fixtures/112-mask-secret-explicit/params.cfg
+++ b/testdata/fixtures/112-mask-secret-explicit/params.cfg
@@ -1,0 +1,1 @@
+--mask-secrets

--- a/testdata/fixtures/113-mask-secret-disabled/expected_output.txt
+++ b/testdata/fixtures/113-mask-secret-disabled/expected_output.txt
@@ -1,0 +1,12 @@
+Found two differences
+
+data.password  (v1/Secret/app-secret)
+  ± value change
+    - aGVsbG8=
+    + d29ybGQ=
+
+data.api_key  (v1/Secret/app-secret)
+  ± value change
+    - c2VjcmV0
+    + bmV3LXNlY3JldA==
+

--- a/testdata/fixtures/113-mask-secret-disabled/file1.yaml
+++ b/testdata/fixtures/113-mask-secret-disabled/file1.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+data:
+  password: aGVsbG8=
+  api_key: c2VjcmV0

--- a/testdata/fixtures/113-mask-secret-disabled/file2.yaml
+++ b/testdata/fixtures/113-mask-secret-disabled/file2.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+data:
+  password: d29ybGQ=
+  api_key: bmV3LXNlY3JldA==

--- a/testdata/fixtures/113-mask-secret-disabled/params.cfg
+++ b/testdata/fixtures/113-mask-secret-disabled/params.cfg
@@ -1,0 +1,1 @@
+--mask-secrets=false

--- a/testdata/fixtures/114-mask-custom-path/expected_output.txt
+++ b/testdata/fixtures/114-mask-custom-path/expected_output.txt
@@ -1,0 +1,12 @@
+Found two differences
+
+data.api_key  (v1/ConfigMap/app-config)
+  ± value change
+    - ***
+    + ***
+
+data.log_level  (v1/ConfigMap/app-config)
+  ± value change
+    - info
+    + debug
+

--- a/testdata/fixtures/114-mask-custom-path/file1.yaml
+++ b/testdata/fixtures/114-mask-custom-path/file1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  api_key: "secret-key-1"
+  log_level: info

--- a/testdata/fixtures/114-mask-custom-path/file2.yaml
+++ b/testdata/fixtures/114-mask-custom-path/file2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  api_key: "secret-key-2"
+  log_level: debug

--- a/testdata/fixtures/114-mask-custom-path/params.cfg
+++ b/testdata/fixtures/114-mask-custom-path/params.cfg
@@ -1,0 +1,1 @@
+--mask-path "data.api_key"

--- a/testdata/fixtures/115-mask-regex/expected_output.txt
+++ b/testdata/fixtures/115-mask-regex/expected_output.txt
@@ -1,0 +1,12 @@
+Found two differences
+
+data.api_key  (v1/ConfigMap/app-config)
+  ± value change
+    - ***
+    + ***
+
+data.log_level  (v1/ConfigMap/app-config)
+  ± value change
+    - info
+    + debug
+

--- a/testdata/fixtures/115-mask-regex/file1.yaml
+++ b/testdata/fixtures/115-mask-regex/file1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  api_key: "secret-key-1"
+  log_level: info

--- a/testdata/fixtures/115-mask-regex/file2.yaml
+++ b/testdata/fixtures/115-mask-regex/file2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  api_key: "secret-key-2"
+  log_level: debug

--- a/testdata/fixtures/115-mask-regex/params.cfg
+++ b/testdata/fixtures/115-mask-regex/params.cfg
@@ -1,0 +1,1 @@
+--mask-path-regexp "(?i)key"

--- a/testdata/fixtures/116-mask-secret-added/expected_output.txt
+++ b/testdata/fixtures/116-mask-secret-added/expected_output.txt
@@ -1,0 +1,13 @@
+Found one difference
+
+(document)  (v1/Secret/db-secret)
+  + one document added:
+    ---
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: db-secret
+    type: Opaque
+    data:
+      password: ***
+

--- a/testdata/fixtures/116-mask-secret-added/file1.yaml
+++ b/testdata/fixtures/116-mask-secret-added/file1.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  log_level: info

--- a/testdata/fixtures/116-mask-secret-added/file2.yaml
+++ b/testdata/fixtures/116-mask-secret-added/file2.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  log_level: info
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secret
+type: Opaque
+data:
+  password: aGVsbG8=

--- a/testdata/fixtures/116-mask-secret-added/params.cfg
+++ b/testdata/fixtures/116-mask-secret-added/params.cfg
@@ -1,0 +1,1 @@
+--mask-secrets

--- a/testdata/fixtures/117-mask-stringdata/expected_output.txt
+++ b/testdata/fixtures/117-mask-stringdata/expected_output.txt
@@ -1,0 +1,7 @@
+Found one difference
+
+stringData.token  (v1/Secret/app-secret)
+  ± value change
+    - ***
+    + ***
+

--- a/testdata/fixtures/117-mask-stringdata/file1.yaml
+++ b/testdata/fixtures/117-mask-stringdata/file1.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+stringData:
+  token: "abc-123"

--- a/testdata/fixtures/117-mask-stringdata/file2.yaml
+++ b/testdata/fixtures/117-mask-stringdata/file2.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+type: Opaque
+stringData:
+  token: "xyz-789"

--- a/testdata/fixtures/117-mask-stringdata/params.cfg
+++ b/testdata/fixtures/117-mask-stringdata/params.cfg
@@ -1,0 +1,1 @@
+--mask-secrets


### PR DESCRIPTION
## What

Add opt-in sensitive value masking so secret material never reaches stdout.

## Why

diffyml currently emits raw values for every changed field, including `data` and `stringData` of Kubernetes Secret resources. In CI logs, PR comments, GitHub Annotations, and the AI-summarizer prompt, this exposes base64-encoded secrets to anyone who can read the build output. Several environments (regulated K8s teams, GitOps repos, security reviews) treat this as a credibility blocker.

## How

Single post-comparison masking pass over `[]Difference`. Mutating values once at the diff layer means every formatter — `detailed`, `compact`, `brief`, `github`, `gitlab`, `gitea`, `json`, `json-patch` — and the AI summarizer all see the redacted value with zero per-format wiring.

**New flags / config keys:**
- `--mask-secrets` — auto-mask `data` / `stringData` on documents whose `kind` is `Secret`
- `--mask-path` — additional dot-notation paths (prefix match, repeatable)
- `--mask-path-regexp` — regex variant
- `--mask-placeholder` — defaults to `***`

**Design notes:**
- **Opt-in** — no behavior change for existing users.
- **`DocumentKind` field** added to `Difference` so the masking pass can identify Secret docs without parsing `DocumentName` (apiVersion can contain `/`, e.g. `apps/v1`).
- **Two mask scopes:** value-level (path-targeted) and Secret-subtree (when an entire Secret document is added/removed, only `data` / `stringData` get masked — `apiVersion`, `kind`, `metadata` stay visible).
- **Order-change diffs are never masked** (their values are identifier lists).
- **Pipeline order:** Compare → MaskDifferences → FilterDiffsWithRegexp → Format. Masking runs before filtering so users can still exclude entirely-masked diffs if desired.

**Path matching** reuses `pathMatches` from `filter.go`. Leading document-index segments (`[0]`, `[1]`) are stripped before matching so `--mask-path 'data.password'` works for both single- and multi-doc files.

## Checklist

- [x] PR title follows convention (`feat:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests (19 unit tests + 6 snapshot fixtures)
- [x] Coverage thresholds met (99.2% total)
- [x] No new dependencies

## Notes for reviewers

- `pkg/diffyml/mask.go` is the entire feature — ~190 lines.
- Snapshot fixtures `112-mask-secret-explicit` through `117-mask-stringdata` exercise all combinations.
- `DocumentKind` is a non-breaking addition to the public `Difference` struct (zero-valued for non-K8s docs).
- The CLI reference page (`docs/content/docs/reference.md`) is regenerated; the `Masking` category was added to `doc/gen-cli-ref/main.go`'s `categoryOrder`.
