### PR TITLE
feat: migrate mutation testing from gremlins to gomutant

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,27 +14,7 @@ on:
     branches: [main]
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          filters: |
-            code:
-              - '**/*.go'
-              - 'go.mod'
-              - 'go.sum'
-
   mutation:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -10,8 +10,16 @@ concurrency:
 on:
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
   push:
     branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   mutation:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -10,6 +10,8 @@ concurrency:
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   changes:
@@ -38,30 +40,87 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+          # --changed-since needs the merge-base with the PR base ref
+          # available locally; the default shallow clone hides it.
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.2"
 
-      - name: Install gremlins
-        run: go install github.com/go-gremlins/gremlins/cmd/gremlins@v0.6.0
+      - name: Install gomutant
+        run: go install github.com/szhekpisov/gomutant@v0.1.0
 
-      - name: Run mutation testing
+      # PRs: --changed-since limits work to touched lines; gate on
+      # "no LIVED mutant in the diff".
+      - name: Run mutation testing (PR — diff only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: >-
-          gremlins unleash
+          gomutant unleash
+          --workers 2
+          --coverpkg="./pkg/diffyml/..."
+          --changed-since="origin/${BASE_REF}"
+          --output=mutation-report.json
+          ./pkg/diffyml/
+
+      # Push to main: full-tree run; gate on the absolute test_efficacy
+      # floor (catches coverage rot in code no PR happens to touch).
+      - name: Run mutation testing (post-merge — full)
+        if: github.event_name == 'push'
+        run: >-
+          gomutant unleash
           --workers 2
           --coverpkg="./pkg/diffyml/..."
           --output=mutation-report.json
           ./pkg/diffyml/
 
-      - name: Check efficacy threshold
+      # On --changed-since runs the absolute test_efficacy floor isn't
+      # meaningful (subset varies per PR). Gate on "no LIVED mutant on
+      # changed lines": every mutation introduced by the PR must die.
+      - name: Gate on lived mutants (PR)
+        if: github.event_name == 'pull_request'
         run: |
-          EFFICACY=$(jq '.test_efficacy' mutation-report.json)
-          echo "Test efficacy: ${EFFICACY}%"
-          THRESHOLD=100
-          if [ "$(echo "$EFFICACY < $THRESHOLD" | bc -l)" -eq 1 ]; then
+          set -euo pipefail
+          if [ ! -s mutation-report.json ]; then
+            echo "::error::mutation-report.json missing or empty"
+            exit 1
+          fi
+          TOTAL=$(jq -r '.mutants_total // 0' mutation-report.json)
+          KILLED=$(jq -r '.mutants_killed // 0' mutation-report.json)
+          LIVED=$(jq -r '.mutants_lived // 0' mutation-report.json)
+          NOT_VIABLE=$(jq -r '.mutants_not_viable // 0' mutation-report.json)
+          NOT_COVERED=$(jq -r '.mutants_not_covered // 0' mutation-report.json)
+          TIMED_OUT=$(( TOTAL - KILLED - LIVED - NOT_VIABLE - NOT_COVERED ))
+          echo "Mutants on changed lines: total=${TOTAL} killed=${KILLED} lived=${LIVED} not_viable=${NOT_VIABLE} not_covered=${NOT_COVERED} timed_out=${TIMED_OUT}"
+          if [ "${LIVED}" -gt 0 ]; then
+            echo "::error::${LIVED} mutant(s) on changed lines survived — strengthen tests or revert"
+            exit 1
+          fi
+
+      - name: Check efficacy threshold (post-merge)
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          if [ ! -s mutation-report.json ]; then
+            echo "::error::mutation-report.json missing or empty"
+            exit 1
+          fi
+          EFFICACY=$(jq -r '.test_efficacy // empty' mutation-report.json)
+          if [ -z "${EFFICACY}" ]; then
+            echo "::error::test_efficacy missing from mutation-report.json"
+            exit 1
+          fi
+          # Pinned to the local measurement at migration time (gomutant v0.1.0,
+          # 2026-04-29): 85.66% efficacy on 2325 mutants (1666 killed, 279 lived,
+          # 324 not_viable, 34 not_covered, 22 timed_out). gomutant runs ~16
+          # mutators vs gremlins' 11, so the absolute number is lower than the
+          # legacy 100% figure. Ratchet up as tests improve.
+          THRESHOLD=85.65
+          echo "Test efficacy: ${EFFICACY}% (required: ${THRESHOLD}%)"
+          if [ "$(echo "${EFFICACY} < ${THRESHOLD}" | bc -l)" -eq 1 ]; then
             echo "::error::Mutation test efficacy ${EFFICACY}% is below ${THRESHOLD}% threshold"
             exit 1
           fi

--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,11 @@ fuzz-long:
 	done
 
 mutation:
-	gremlins unleash --workers 10 --coverpkg="./pkg/diffyml/..." --output=mutation-report.json ./pkg/diffyml/
+	gomutant unleash --workers 10 --coverpkg="./pkg/diffyml/..." --output=mutation-report.json ./pkg/diffyml/
 	go clean -cache
 
 mutation-dry:
-	gremlins unleash --dry-run --coverpkg="./pkg/diffyml/..." ./pkg/diffyml/
+	gomutant unleash --dry-run --coverpkg="./pkg/diffyml/..." ./pkg/diffyml/
 
 ci: fmt vet test check-coverage security docs-check
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ See the [package documentation](https://pkg.go.dev/github.com/szhekpisov/diffyml
   [misspell](https://github.com/client9/misspell),
   [staticcheck](https://staticcheck.dev/) (all checks except style conventions)
 
-**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 99.4% code coverage, 100% [mutation testing](https://github.com/go-gremlins/gremlins) efficacy (686/686 mutants killed). CI enforces a 99% coverage floor.
+**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 99.4% code coverage, [mutation testing](https://github.com/szhekpisov/gomutant) gated per-PR (no LIVED mutant on changed lines) with an 85.65% post-merge efficacy floor. CI enforces a 99% coverage floor.
 
 **Reporting vulnerabilities.** See [SECURITY.md](SECURITY.md) — preferred path is a [private GitHub Security Advisory](https://github.com/szhekpisov/diffyml/security/advisories/new).
 
@@ -571,14 +571,14 @@ make ci             # full CI pipeline locally (fmt + vet + test + coverage + se
 make bench          # run benchmarks
 make bench-compare  # compare against alternative tools (see doc/PERFORMANCE.md)
 make coverage       # generate HTML coverage report
-make mutation       # run mutation testing (requires gremlins)
+make mutation       # run mutation testing (requires gomutant)
 ```
 
 **CI pipelines** (run on every push and PR):
 - **Tests** — unit tests + coverage thresholds
 - **Security & Static Analysis** — govulncheck + golangci-lint (also runs weekly)
 - **Benchmark** — performance regression tracking
-- **Mutation Testing** — test quality validation via [gremlins](https://github.com/go-gremlins/gremlins)
+- **Mutation Testing** — test quality validation via [gomutant](https://github.com/szhekpisov/gomutant)
 
 </details>
 

--- a/doc/mutation-testing.md
+++ b/doc/mutation-testing.md
@@ -16,35 +16,49 @@ A surviving mutant means either the test suite has a gap, or the mutation is **e
 
 ## Tool
 
-[gremlins](https://github.com/go-gremlins/gremlins) v0.6.0
+[gomutant](https://github.com/szhekpisov/gomutant) v0.1.0
 
 ## CI Integration
 
-The mutation testing workflow (`.github/workflows/mutation.yml`) runs on every PR targeting `main`. It uses `--diff` to only mutate changed code and enforces a 98% efficacy threshold.
+`.github/workflows/mutation.yml` runs in two modes:
+
+- **Pull requests** — `gomutant unleash --changed-since=origin/main` scopes mutation to lines touched by the PR. Gate: any LIVED mutant on changed lines fails the job. This makes mutation testing a per-PR quality bar rather than a periodic audit.
+- **Push to main** — full-tree run after merge. Gate: `test_efficacy ≥ 85.65%` (the calibrated floor at gomutant migration; ratchet up as tests improve). Catches coverage rot in code no PR happens to touch.
 
 ## Report
 
-**Last full run:** 2026-03-12 — efficacy 100.00% (575 killed / 575 covered), 0 lived
-**Mutator coverage:** 99.31%
+**Last full run:** 2026-04-29 — efficacy 85.66% on 2325 mutants (gomutant v0.1.0)
+**Mutations coverage:** 98.54%
 
 | Status | Count |
 |--------|-------|
-| Killed | 575 |
-| Lived | 0 |
-| Timed out | 0 |
-| Not covered | 4 |
-| **Efficacy** | **100.00%** |
-| **Mutator coverage** | **99.31%** |
+| Killed | 1666 |
+| Lived | 279 |
+| Not viable | 324 |
+| Not covered | 34 |
+| Timed out | 22 |
+| **Efficacy** | **85.66%** |
+| **Mutations coverage** | **98.54%** |
 
-## Not Covered (4 mutants)
+The drop from the legacy 100% figure reflects gomutant's larger mutator set (~16 active mutators vs. gremlins' 11). New mutators — chiefly `STATEMENT_REMOVE`, `EXPRESSION_REMOVE`, `BRANCH_CASE`, and `INVERT_LOOP_CTRL` — probe locations the gremlins-era suite did not exercise. The 279 lived mutants represent a mix of real test gaps and equivalent mutants; the PR-scoped gate prevents new ones from sneaking in while the floor is ratcheted up.
 
-4 mutants remain NOT COVERED. All are `ARITHMETIC_BASE` mutations on package-level constants. Constants are compile-time expressions that do not appear as executable statements in Go's `-coverprofile`, so gremlins cannot determine whether they are tested.
+## Lived Mutants by File (top 10)
 
-| File | Line | Constant |
-|------|------|----------|
-| `remote.go` | 14:23 | `MaxResponseSize = 10 * 1024 * 1024` |
-| `remote.go` | 14:30 | `MaxResponseSize = 10 * 1024 * 1024` |
-| `remote.go` | 16:22 | `DefaultTimeout = 30 * time.Second` |
-| `cli/summarizer.go` | 26:24 | `summaryTimeout = 30 * time.Second` |
+| File | Lived | Total |
+|------|------:|------:|
+| `comparator.go` | 44 | 332 |
+| `formatter.go` | 36 | 295 |
+| `kubernetes.go` | 32 | 126 |
+| `diffyml.go` | 23 | 155 |
+| `detailed_formatter.go` | 22 | 181 |
+| `rename.go` | 18 | 102 |
+| `color.go` | 16 | 114 |
+| `chroot.go` | 15 | 90 |
+| `diffpath.go` | 14 | 90 |
+| `inline_diff.go` | 10 | 76 |
 
-These constants are exercised by unit tests (`TestRemoteConstants`, `TestSummarize_Timeout`), but since Go does not instrument constant declarations, they will always be reported as NOT COVERED by gremlins.
+By mutator: `STATEMENT_REMOVE` (77), `EXPRESSION_REMOVE` (74), `BRANCH_IF` (61), `INVERT_LOGICAL` (28), `BRANCH_CASE` (18), `INVERT_LOOP_CTRL` (17), `INVERT_BITWISE` (3), `REMOVE_SELF_ASSIGNMENTS` (1).
+
+## Not Covered
+
+34 mutants are NOT COVERED — predominantly `ARITHMETIC_BASE` mutations on package-level constants. Go does not instrument constant declarations in `-coverprofile`, so gomutant cannot determine whether they are tested even when they are exercised by unit tests (e.g., `TestRemoteConstants`, `TestSummarize_Timeout`). These will always report as NOT COVERED regardless of test additions; full enumeration is in `mutation-report.json`.

--- a/pkg/diffyml/cli/directory.go
+++ b/pkg/diffyml/cli/directory.go
@@ -130,7 +130,7 @@ func buildFilePairsFromMap(m map[string][2][]byte) []diffyml.FilePair {
 		contents := m[name]
 		var pair diffyml.FilePair
 		pair.Name = name
-		//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gremlins to misclassify mutations as NOT COVERED
+		//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gomutant to misclassify mutations as NOT COVERED
 		if contents[0] != nil && contents[1] != nil {
 			pair.Type = diffyml.FilePairBothExist
 		} else if contents[0] != nil {

--- a/pkg/diffyml/cli/summarizer.go
+++ b/pkg/diffyml/cli/summarizer.go
@@ -161,7 +161,7 @@ func (s *Summarizer) Summarize(ctx context.Context, groups []diffyml.DiffGroup) 
 
 // checkHTTPError converts HTTP error status codes into descriptive errors.
 func checkHTTPError(statusCode int, result *messagesResponse) error {
-	//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gremlins to misclassify mutations as NOT COVERED
+	//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gomutant to misclassify mutations as NOT COVERED
 	if statusCode == 401 {
 		return fmt.Errorf("invalid API key")
 	} else if statusCode == 429 {

--- a/pkg/diffyml/coverage_gaps_test.go
+++ b/pkg/diffyml/coverage_gaps_test.go
@@ -10,7 +10,7 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// Tests targeting remaining coverage gaps identified by gremlins mutation testing.
+// Tests targeting remaining coverage gaps identified by gomutant mutation testing.
 
 // --- deepEqual: *OrderedMap different lengths ---
 

--- a/pkg/diffyml/plainmap_coverage_test.go
+++ b/pkg/diffyml/plainmap_coverage_test.go
@@ -7,7 +7,7 @@ import (
 
 // Tests for code paths that handle map[string]any values.
 // The parser always produces *OrderedMap, but these branches exist as
-// defensive handling for direct callers. We test them to kill gremlins mutants.
+// defensive handling for direct callers. We test them to kill gomutant mutants.
 
 // --- compareNodes with map[string]any ---
 


### PR DESCRIPTION
## What

Replace `gremlins` with [`gomutant`](https://github.com/szhekpisov/gomutant) v0.1.0 as the mutation testing tool. Restructure `mutation.yml` into two modes: per-PR diff-scoped runs, full-tree runs after merge.

## Why

- **Stronger gate.** gomutant runs 16 mutators vs gremlins' 11 (`STATEMENT_REMOVE`, `EXPRESSION_REMOVE`, `BRANCH_CASE`, `BRANCH_IF`, `BRANCH_ELSE` added) and is more thorough within the shared set. On the matched 11-mutator subset, gomutant discovers **793** mutants vs gremlins' **575** for the same source — gremlins' 100% efficacy reflected discovery gaps, not a perfect test suite. With gomutant's full set, true efficacy is 85.66% (1666 killed / 279 lived / 34 not_covered / 324 not_viable / 22 timed_out on 2325 mutants).
- **Per-PR quality bar.** `--changed-since=origin/main` scopes mutation testing to each PR's touched lines. Gate: any LIVED mutant on changed lines fails the job. Faster (typical PR < 1 min) and more actionable than a periodic audit.
- **Drop-in.** Same `unleash` subcommand, same JSON report shape, same flags. The migration is a tool swap, not a rewrite of how mutation testing works in this repo.

## How

**Workflow (`.github/workflows/mutation.yml`)** — triggers expanded to `pull_request` *and* `push: branches: [main]`. Single job branches on `github.event_name`:

- **PR mode:** `gomutant unleash --changed-since=origin/${BASE_REF}`. Gate parses `mutants_lived` from the JSON report; fails if > 0. Defensive `jq // 0` defaults so a partial report fails loudly rather than opaquely.
- **Post-merge mode:** full-tree run; gate on `test_efficacy ≥ 85.65%` (today's calibrated floor — comment in the workflow explains the migration baseline and points at ratcheting).

`fetch-depth: 0` added so `--changed-since` can resolve `origin/main`. Pattern lifted directly from gomutant's own CI.

**Makefile** — `gremlins unleash` → `gomutant unleash` (same flags). `make mutation` and `make mutation-dry` work unchanged from the user's perspective.

**Docs** — `doc/mutation-testing.md` rewritten with today's numbers, a per-file lived-mutants table for ratcheting work, and a per-mutator breakdown. README's mutation-testing claim updated from "100% efficacy" to an honest description of the new gating model. Code comments referencing gremlins (the `nolint:gocritic` blocks explaining if-else preference, test file comments) updated to point at gomutant.

## Checklist

- [x] PR title follows convention (`feat:`)
- [ ] `make ci` passes locally — not run in this session; only docs/comments/CI YAML and Makefile changed, source code untouched
- [x] New/changed behavior covered by tests — the "behavior change" is in CI workflow + tooling; no production code paths changed
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%) — no source changes
- [x] No new dependencies (or justified) — gomutant replaces gremlins; pure-Go CLI installed via `go install`, no module dependency

## Notes for reviewers

- **The 100% → 85.65% efficacy "regression" is a measurement change, not a quality regression.** gremlins was over-reporting; gomutant's stricter AST walker surfaces real coverage gaps. PR-level gate (no LIVED on diff) is the strong gate now; the post-merge floor is just a regression alarm.
- **Ratchet plan.** `doc/mutation-testing.md` lists the top-10 lived-mutant files (comparator.go: 44, formatter.go: 36, kubernetes.go: 32, ...). As tests are added, the post-merge `THRESHOLD` in `mutation.yml` can be ratcheted up.
- **Comparison data.** Side-by-side gomutant matched-11-set vs gremlins' main-branch report: gomutant 678 killed / 49 lived / 21 not_covered / 42 not_viable (93.26% efficacy) on the same source with the same nominal mutator set. Confirms the discovery-side gap rather than a tool-quality regression.
- The first push to main after merge will run the full mutation suite (~12 min); plan accordingly.