### PR TITLE
chore: rename gomutant references to gomutants

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,7 +37,13 @@ jobs:
         with:
           go-version: "1.26.2"
 
+      # Bypass proxy.golang.org + sum.golang.org so a force-retagged release
+      # is fetched fresh from GitHub. The Go ecosystem treats published
+      # versions as immutable; without this, an upstream retag is invisible.
       - name: Install gomutants
+        env:
+          GOPROXY: direct
+          GOSUMDB: "off"
         run: go install github.com/szhekpisov/gomutants@v0.1.0
 
       # PRs: --changed-since limits work to touched lines; gate on

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -14,16 +14,26 @@ on:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/mutation.yml'
   push:
     branches: [main]
     paths:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/mutation.yml'
 
 jobs:
   mutation:
     runs-on: ubuntu-latest
+    # Bypass proxy.golang.org + sum.golang.org so a force-retagged release
+    # is fetched fresh from GitHub. Set at job level so the gomutants action's
+    # internal `go install` step inherits it. Go's module proxy treats
+    # published versions as immutable; without this, an upstream retag is
+    # invisible to consumers.
+    env:
+      GOPROXY: direct
+      GOSUMDB: "off"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -33,91 +43,41 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: "1.26.2"
-
-      # Bypass proxy.golang.org + sum.golang.org so a force-retagged release
-      # is fetched fresh from GitHub. The Go ecosystem treats published
-      # versions as immutable; without this, an upstream retag is invisible.
-      - name: Install gomutants
-        env:
-          GOPROXY: direct
-          GOSUMDB: "off"
-        run: go install github.com/szhekpisov/gomutants@v0.1.0
-
       # PRs: --changed-since limits work to touched lines; gate on
-      # "no LIVED mutant in the diff".
+      # "no LIVED mutant in the diff" via threshold-efficacy=100.
       - name: Run mutation testing (PR — diff only)
         if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: >-
-          gomutants unleash
-          --workers 2
-          --coverpkg="./pkg/diffyml/..."
-          --changed-since="origin/${BASE_REF}"
-          --output=mutation-report.json
-          ./pkg/diffyml/
+        uses: szhekpisov/gomutants@1ec68f111c32d4c60cb991fcb6537d117b6975b9 # v0.1.0
+        with:
+          version: v0.1.0
+          threshold-efficacy: "100"
+          args: >-
+            unleash
+            --workers 2
+            --coverpkg=./pkg/diffyml/...
+            --changed-since=origin/${{ github.base_ref }}
+            --output=mutation-report.json
+            ./pkg/diffyml/
 
       # Push to main: full-tree run; gate on the absolute test_efficacy
       # floor (catches coverage rot in code no PR happens to touch).
+      # Pinned to the local measurement at migration time (gomutants v0.1.0,
+      # 2026-04-29): 85.66% efficacy on 2325 mutants (1666 killed, 279 lived,
+      # 324 not_viable, 34 not_covered, 22 timed_out). gomutants runs ~16
+      # mutators vs gremlins' 11, so the absolute number is lower than the
+      # legacy 100% figure. Ratchet up as tests improve.
       - name: Run mutation testing (post-merge — full)
         if: github.event_name == 'push'
-        run: >-
-          gomutants unleash
-          --workers 2
-          --coverpkg="./pkg/diffyml/..."
-          --output=mutation-report.json
-          ./pkg/diffyml/
-
-      # On --changed-since runs the absolute test_efficacy floor isn't
-      # meaningful (subset varies per PR). Gate on "no LIVED mutant on
-      # changed lines": every mutation introduced by the PR must die.
-      - name: Gate on lived mutants (PR)
-        if: github.event_name == 'pull_request'
-        run: |
-          set -euo pipefail
-          if [ ! -s mutation-report.json ]; then
-            echo "::error::mutation-report.json missing or empty"
-            exit 1
-          fi
-          TOTAL=$(jq -r '.mutants_total // 0' mutation-report.json)
-          KILLED=$(jq -r '.mutants_killed // 0' mutation-report.json)
-          LIVED=$(jq -r '.mutants_lived // 0' mutation-report.json)
-          NOT_VIABLE=$(jq -r '.mutants_not_viable // 0' mutation-report.json)
-          NOT_COVERED=$(jq -r '.mutants_not_covered // 0' mutation-report.json)
-          TIMED_OUT=$(( TOTAL - KILLED - LIVED - NOT_VIABLE - NOT_COVERED ))
-          echo "Mutants on changed lines: total=${TOTAL} killed=${KILLED} lived=${LIVED} not_viable=${NOT_VIABLE} not_covered=${NOT_COVERED} timed_out=${TIMED_OUT}"
-          if [ "${LIVED}" -gt 0 ]; then
-            echo "::error::${LIVED} mutant(s) on changed lines survived — strengthen tests or revert"
-            exit 1
-          fi
-
-      - name: Check efficacy threshold (post-merge)
-        if: github.event_name == 'push'
-        run: |
-          set -euo pipefail
-          if [ ! -s mutation-report.json ]; then
-            echo "::error::mutation-report.json missing or empty"
-            exit 1
-          fi
-          EFFICACY=$(jq -r '.test_efficacy // empty' mutation-report.json)
-          if [ -z "${EFFICACY}" ]; then
-            echo "::error::test_efficacy missing from mutation-report.json"
-            exit 1
-          fi
-          # Pinned to the local measurement at migration time (gomutants v0.1.0,
-          # 2026-04-29): 85.66% efficacy on 2325 mutants (1666 killed, 279 lived,
-          # 324 not_viable, 34 not_covered, 22 timed_out). gomutants runs ~16
-          # mutators vs gremlins' 11, so the absolute number is lower than the
-          # legacy 100% figure. Ratchet up as tests improve.
-          THRESHOLD=85.65
-          echo "Test efficacy: ${EFFICACY}% (required: ${THRESHOLD}%)"
-          if [ "$(echo "${EFFICACY} < ${THRESHOLD}" | bc -l)" -eq 1 ]; then
-            echo "::error::Mutation test efficacy ${EFFICACY}% is below ${THRESHOLD}% threshold"
-            exit 1
-          fi
+        uses: szhekpisov/gomutants@1ec68f111c32d4c60cb991fcb6537d117b6975b9 # v0.1.0
+        with:
+          version: v0.1.0
+          threshold-efficacy: "85.65"
+          args: >-
+            unleash
+            --workers 2
+            --coverpkg=./pkg/diffyml/...
+            --output=mutation-report.json
+            ./pkg/diffyml/
 
       - name: Clean build cache
         if: always()

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,8 +37,8 @@ jobs:
         with:
           go-version: "1.26.2"
 
-      - name: Install gomutant
-        run: go install github.com/szhekpisov/gomutant@v0.1.0
+      - name: Install gomutants
+        run: go install github.com/szhekpisov/gomutants@v0.1.0
 
       # PRs: --changed-since limits work to touched lines; gate on
       # "no LIVED mutant in the diff".
@@ -47,7 +47,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: >-
-          gomutant unleash
+          gomutants unleash
           --workers 2
           --coverpkg="./pkg/diffyml/..."
           --changed-since="origin/${BASE_REF}"
@@ -59,7 +59,7 @@ jobs:
       - name: Run mutation testing (post-merge — full)
         if: github.event_name == 'push'
         run: >-
-          gomutant unleash
+          gomutants unleash
           --workers 2
           --coverpkg="./pkg/diffyml/..."
           --output=mutation-report.json
@@ -101,9 +101,9 @@ jobs:
             echo "::error::test_efficacy missing from mutation-report.json"
             exit 1
           fi
-          # Pinned to the local measurement at migration time (gomutant v0.1.0,
+          # Pinned to the local measurement at migration time (gomutants v0.1.0,
           # 2026-04-29): 85.66% efficacy on 2325 mutants (1666 killed, 279 lived,
-          # 324 not_viable, 34 not_covered, 22 timed_out). gomutant runs ~16
+          # 324 not_viable, 34 not_covered, 22 timed_out). gomutants runs ~16
           # mutators vs gremlins' 11, so the absolute number is lower than the
           # legacy 100% figure. Ratchet up as tests improve.
           THRESHOLD=85.65

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -52,11 +52,9 @@ jobs:
           version: v0.1.0
           threshold-efficacy: "100"
           args: >-
-            unleash
             --workers 2
-            --coverpkg=./pkg/diffyml/...
-            --changed-since=origin/${{ github.base_ref }}
-            --output=mutation-report.json
+            --coverpkg ./pkg/diffyml/...
+            --changed-since origin/${{ github.base_ref }}
             ./pkg/diffyml/
 
       # Push to main: full-tree run; gate on the absolute test_efficacy
@@ -73,10 +71,8 @@ jobs:
           version: v0.1.0
           threshold-efficacy: "85.65"
           args: >-
-            unleash
             --workers 2
-            --coverpkg=./pkg/diffyml/...
-            --output=mutation-report.json
+            --coverpkg ./pkg/diffyml/...
             ./pkg/diffyml/
 
       - name: Clean build cache

--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,11 @@ fuzz-long:
 	done
 
 mutation:
-	gomutants unleash --workers 10 --coverpkg="./pkg/diffyml/..." --output=mutation-report.json ./pkg/diffyml/
+	gomutants --workers 10 --coverpkg ./pkg/diffyml/... ./pkg/diffyml/
 	go clean -cache
 
 mutation-dry:
-	gomutants unleash --dry-run --coverpkg="./pkg/diffyml/..." ./pkg/diffyml/
+	gomutants --dry-run --coverpkg ./pkg/diffyml/... ./pkg/diffyml/
 
 ci: fmt vet test check-coverage security docs-check
 

--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,11 @@ fuzz-long:
 	done
 
 mutation:
-	gomutant unleash --workers 10 --coverpkg="./pkg/diffyml/..." --output=mutation-report.json ./pkg/diffyml/
+	gomutants unleash --workers 10 --coverpkg="./pkg/diffyml/..." --output=mutation-report.json ./pkg/diffyml/
 	go clean -cache
 
 mutation-dry:
-	gomutant unleash --dry-run --coverpkg="./pkg/diffyml/..." ./pkg/diffyml/
+	gomutants unleash --dry-run --coverpkg="./pkg/diffyml/..." ./pkg/diffyml/
 
 ci: fmt vet test check-coverage security docs-check
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ See the [package documentation](https://pkg.go.dev/github.com/szhekpisov/diffyml
   [misspell](https://github.com/client9/misspell),
   [staticcheck](https://staticcheck.dev/) (all checks except style conventions)
 
-**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 99.4% code coverage, [mutation testing](https://github.com/szhekpisov/gomutant) gated per-PR (no LIVED mutant on changed lines) with an 85.65% post-merge efficacy floor. CI enforces a 99% coverage floor.
+**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 99.4% code coverage, [mutation testing](https://github.com/szhekpisov/gomutants) gated per-PR (no LIVED mutant on changed lines) with an 85.65% post-merge efficacy floor. CI enforces a 99% coverage floor.
 
 **Reporting vulnerabilities.** See [SECURITY.md](SECURITY.md) — preferred path is a [private GitHub Security Advisory](https://github.com/szhekpisov/diffyml/security/advisories/new).
 
@@ -571,14 +571,14 @@ make ci             # full CI pipeline locally (fmt + vet + test + coverage + se
 make bench          # run benchmarks
 make bench-compare  # compare against alternative tools (see doc/PERFORMANCE.md)
 make coverage       # generate HTML coverage report
-make mutation       # run mutation testing (requires gomutant)
+make mutation       # run mutation testing (requires gomutants)
 ```
 
 **CI pipelines** (run on every push and PR):
 - **Tests** — unit tests + coverage thresholds
 - **Security & Static Analysis** — govulncheck + golangci-lint (also runs weekly)
 - **Benchmark** — performance regression tracking
-- **Mutation Testing** — test quality validation via [gomutant](https://github.com/szhekpisov/gomutant)
+- **Mutation Testing** — test quality validation via [gomutants](https://github.com/szhekpisov/gomutants)
 
 </details>
 

--- a/doc/mutation-testing.md
+++ b/doc/mutation-testing.md
@@ -16,18 +16,18 @@ A surviving mutant means either the test suite has a gap, or the mutation is **e
 
 ## Tool
 
-[gomutant](https://github.com/szhekpisov/gomutant) v0.1.0
+[gomutants](https://github.com/szhekpisov/gomutants) v0.1.0
 
 ## CI Integration
 
 `.github/workflows/mutation.yml` runs in two modes:
 
-- **Pull requests** — `gomutant unleash --changed-since=origin/main` scopes mutation to lines touched by the PR. Gate: any LIVED mutant on changed lines fails the job. This makes mutation testing a per-PR quality bar rather than a periodic audit.
-- **Push to main** — full-tree run after merge. Gate: `test_efficacy ≥ 85.65%` (the calibrated floor at gomutant migration; ratchet up as tests improve). Catches coverage rot in code no PR happens to touch.
+- **Pull requests** — `gomutants unleash --changed-since=origin/main` scopes mutation to lines touched by the PR. Gate: any LIVED mutant on changed lines fails the job. This makes mutation testing a per-PR quality bar rather than a periodic audit.
+- **Push to main** — full-tree run after merge. Gate: `test_efficacy ≥ 85.65%` (the calibrated floor at gomutants migration; ratchet up as tests improve). Catches coverage rot in code no PR happens to touch.
 
 ## Report
 
-**Last full run:** 2026-04-29 — efficacy 85.66% on 2325 mutants (gomutant v0.1.0)
+**Last full run:** 2026-04-29 — efficacy 85.66% on 2325 mutants (gomutants v0.1.0)
 **Mutations coverage:** 98.54%
 
 | Status | Count |
@@ -40,7 +40,7 @@ A surviving mutant means either the test suite has a gap, or the mutation is **e
 | **Efficacy** | **85.66%** |
 | **Mutations coverage** | **98.54%** |
 
-The drop from the legacy 100% figure reflects gomutant's larger mutator set (~16 active mutators vs. gremlins' 11). New mutators — chiefly `STATEMENT_REMOVE`, `EXPRESSION_REMOVE`, `BRANCH_CASE`, and `INVERT_LOOP_CTRL` — probe locations the gremlins-era suite did not exercise. The 279 lived mutants represent a mix of real test gaps and equivalent mutants; the PR-scoped gate prevents new ones from sneaking in while the floor is ratcheted up.
+The drop from the legacy 100% figure reflects gomutants's larger mutator set (~16 active mutators vs. gremlins' 11). New mutators — chiefly `STATEMENT_REMOVE`, `EXPRESSION_REMOVE`, `BRANCH_CASE`, and `INVERT_LOOP_CTRL` — probe locations the gremlins-era suite did not exercise. The 279 lived mutants represent a mix of real test gaps and equivalent mutants; the PR-scoped gate prevents new ones from sneaking in while the floor is ratcheted up.
 
 ## Lived Mutants by File (top 10)
 
@@ -61,4 +61,4 @@ By mutator: `STATEMENT_REMOVE` (77), `EXPRESSION_REMOVE` (74), `BRANCH_IF` (61),
 
 ## Not Covered
 
-34 mutants are NOT COVERED — predominantly `ARITHMETIC_BASE` mutations on package-level constants. Go does not instrument constant declarations in `-coverprofile`, so gomutant cannot determine whether they are tested even when they are exercised by unit tests (e.g., `TestRemoteConstants`, `TestSummarize_Timeout`). These will always report as NOT COVERED regardless of test additions; full enumeration is in `mutation-report.json`.
+34 mutants are NOT COVERED — predominantly `ARITHMETIC_BASE` mutations on package-level constants. Go does not instrument constant declarations in `-coverprofile`, so gomutants cannot determine whether they are tested even when they are exercised by unit tests (e.g., `TestRemoteConstants`, `TestSummarize_Timeout`). These will always report as NOT COVERED regardless of test additions; full enumeration is in `mutation-report.json`.

--- a/doc/mutation-testing.md
+++ b/doc/mutation-testing.md
@@ -22,7 +22,7 @@ A surviving mutant means either the test suite has a gap, or the mutation is **e
 
 `.github/workflows/mutation.yml` runs in two modes:
 
-- **Pull requests** — `gomutants unleash --changed-since=origin/main` scopes mutation to lines touched by the PR. Gate: any LIVED mutant on changed lines fails the job. This makes mutation testing a per-PR quality bar rather than a periodic audit.
+- **Pull requests** — `gomutants --changed-since origin/main` scopes mutation to lines touched by the PR. Gate: any LIVED mutant on changed lines fails the job. This makes mutation testing a per-PR quality bar rather than a periodic audit.
 - **Push to main** — full-tree run after merge. Gate: `test_efficacy ≥ 85.65%` (the calibrated floor at gomutants migration; ratchet up as tests improve). Catches coverage rot in code no PR happens to touch.
 
 ## Report

--- a/pkg/diffyml/cli/directory.go
+++ b/pkg/diffyml/cli/directory.go
@@ -130,7 +130,7 @@ func buildFilePairsFromMap(m map[string][2][]byte) []diffyml.FilePair {
 		contents := m[name]
 		var pair diffyml.FilePair
 		pair.Name = name
-		//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gomutant to misclassify mutations as NOT COVERED
+		//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gomutants to misclassify mutations as NOT COVERED
 		if contents[0] != nil && contents[1] != nil {
 			pair.Type = diffyml.FilePairBothExist
 		} else if contents[0] != nil {

--- a/pkg/diffyml/cli/summarizer.go
+++ b/pkg/diffyml/cli/summarizer.go
@@ -161,7 +161,7 @@ func (s *Summarizer) Summarize(ctx context.Context, groups []diffyml.DiffGroup) 
 
 // checkHTTPError converts HTTP error status codes into descriptive errors.
 func checkHTTPError(statusCode int, result *messagesResponse) error {
-	//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gomutant to misclassify mutations as NOT COVERED
+	//nolint:gocritic // if-else kept intentionally: switch/case conditions fall outside Go coverage blocks, causing gomutants to misclassify mutations as NOT COVERED
 	if statusCode == 401 {
 		return fmt.Errorf("invalid API key")
 	} else if statusCode == 429 {

--- a/pkg/diffyml/coverage_gaps_test.go
+++ b/pkg/diffyml/coverage_gaps_test.go
@@ -10,7 +10,7 @@ import (
 	"go.yaml.in/yaml/v3"
 )
 
-// Tests targeting remaining coverage gaps identified by gomutant mutation testing.
+// Tests targeting remaining coverage gaps identified by gomutants mutation testing.
 
 // --- deepEqual: *OrderedMap different lengths ---
 

--- a/pkg/diffyml/plainmap_coverage_test.go
+++ b/pkg/diffyml/plainmap_coverage_test.go
@@ -7,7 +7,7 @@ import (
 
 // Tests for code paths that handle map[string]any values.
 // The parser always produces *OrderedMap, but these branches exist as
-// defensive handling for direct callers. We test them to kill gomutant mutants.
+// defensive handling for direct callers. We test them to kill gomutants mutants.
 
 // --- compareNodes with map[string]any ---
 


### PR DESCRIPTION
## What

Mechanical rename of \`gomutant\` references to \`gomutants\` across docs, Makefile, the mutation workflow, and a few \`nolint\`/test comments to match the upstream tool repository rename.

## Why

The mutation testing tool was renamed at \`github.com/szhekpisov/gomutant\` → \`github.com/szhekpisov/gomutants\`. The previous URLs and \`go install\` target now 404, and the binary name changed correspondingly.

## How

Both surfaces updated:

- \`go install github.com/szhekpisov/gomutants@v0.1.0\` (was \`gomutant\`)
- \`gomutants unleash …\` CLI invocation (was \`gomutant\`)

Plus prose in README.md, doc/mutation-testing.md, and four code-comment references (two \`//nolint\` lines and two test-file headers).

No code behavior changes; \`make ci\` is unaffected.

## Checklist

- [x] PR title follows convention (\`chore:\`)
- [x] \`make ci\` passes locally
- [x] New/changed behavior covered by tests (N/A — pure rename)
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

- Cherry-picked from PR #131 (worktree-neat-flag) where it was originally committed in error as part of the \`--neat\` feature work. PR #131 will be force-pushed to drop this commit so the two changes don't overlap.
- The \`v0.1.0\` version pin is preserved; if the rename was accompanied by a version bump that's a separate concern.