### PR TITLE
doc: simplify license line and add star CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,4 +620,8 @@ This project is heavily inspired by [dyff](https://github.com/homeport/dyff), an
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+[MIT](LICENSE).
+
+---
+
+If you find this project useful, please consider giving it a ⭐ — it helps others discover it.


### PR DESCRIPTION
## What

Tighten the License section in `README.md` to a single-line link and add a footer inviting readers to star the repo.

## Why

The previous "MIT — see [LICENSE](LICENSE)." line was needlessly verbose for a section that exists only to point at the license file. Adding a friendly star CTA helps with discoverability for a niche CLI tool.

## How

- Replace `MIT — see [LICENSE](LICENSE).` with the bare link `[MIT](LICENSE).`
- Append a horizontal rule and a one-line note asking readers to star the repo if they find it useful.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally (docs-only change)
- [x] New/changed behavior covered by tests (n/a — README only)
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Docs-only change, no code touched.