### PR TITLE
chore: make mutation workflow emit visible skipped status

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -10,21 +10,36 @@ concurrency:
 on:
   pull_request:
     branches: [main]
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/mutation.yml'
   push:
     branches: [main]
-    paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/mutation.yml'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/mutation.yml'
+
   mutation:
+    needs: changes
+    # On push to main, always run (catches coverage rot in untouched code).
+    # On PRs, only run when Go source / module / workflow files changed —
+    # the gate emits a visible "skipped" status so branch protection can
+    # require this check.
+    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     # Bypass proxy.golang.org + sum.golang.org so a force-retagged release
     # is fetched fresh from GitHub. Set at job level so the gomutants action's


### PR DESCRIPTION
## What

Convert `.github/workflows/mutation.yml` from a trigger-level `paths:` filter to a `dorny/paths-filter` gate, matching the pattern already used by `test.yml`, `benchmark.yml`, `codeql.yml`, and `security.yml`.

## Why

With the old setup, mutation testing was simply *absent* from docs-only PRs (e.g. #133) because GitHub never instantiates a workflow whose trigger-level `paths:` filter doesn't match. That makes the job unusable as a required status check — branch protection would block forever waiting for a check that never runs. The visible-skip pattern reports a "skipped" status that satisfies required-check rules.

## How

- Drop the `paths:` blocks under `on.pull_request` and `on.push`.
- Add a lightweight `changes` job that runs `dorny/paths-filter` over `**/*.go`, `go.mod`, `go.sum`, and `.github/workflows/mutation.yml`.
- Gate the existing `mutation` job on `github.event_name == 'push' || needs.changes.outputs.code == 'true'` so push-to-main always runs the full-tree mutation suite (catches coverage rot in untouched code), while PRs only run when relevant files changed.

No change to mutation thresholds, gomutants version, or the actual mutation steps.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally (CI-config-only change)
- [x] New/changed behavior covered by tests (n/a — workflow file)
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified) — `dorny/paths-filter` already used elsewhere

## Notes for reviewers

After merge, watch the next docs-only PR — `mutation` should appear as `skipping` in the check list (alongside `test`, `coverage`, etc.) instead of being absent. If you want the check to be required by branch protection, that's now safe to enable.