### PR TITLE
chore: remove GiteaFormatter; route gitea -> GitHubFormatter

### DIFF
--- a/pkg/diffyml/doc.go
+++ b/pkg/diffyml/doc.go
@@ -32,14 +32,15 @@
 //
 // # Formatting output
 //
-// Eight built-in formatters render differences for different audiences:
+// Seven built-in formatters render differences for different audiences:
 //
 //   - [DetailedFormatter] — full human-readable output with inline diffs
 //   - [CompactFormatter] — one line per change
 //   - [BriefFormatter] — summary counts only
 //   - [GitHubFormatter] — GitHub Actions workflow annotations
+//     (also returned for the "gitea" name; Gitea Actions accepts the same
+//     workflow command syntax)
 //   - [GitLabFormatter] — GitLab CI Code Quality JSON
-//   - [GiteaFormatter] — Gitea CI (GitHub-compatible annotations)
 //   - [JSONFormatter] — machine-readable JSON with typed values
 //   - [JSONPatchFormatter] — RFC 6902 JSON Patch operations
 //

--- a/pkg/diffyml/formatter.go
+++ b/pkg/diffyml/formatter.go
@@ -577,26 +577,11 @@ func (f *GitLabFormatter) FormatAll(groups []DiffGroup, _ *FormatOptions) string
 // Uses GitHub Actions compatible format. Note: Gitea Actions silently ignores
 // workflow command annotations (see gitea/gitea#23722), so annotations may not
 // appear in the Gitea UI. The output is still valid for log parsing.
-type GiteaFormatter struct{}
-
-// FormatSingle renders a single difference in Gitea CI format (GitHub Actions compatible).
-func (f *GiteaFormatter) FormatSingle(diff Difference, opts *FormatOptions) string {
-	// Gitea uses GitHub Actions compatible format
-	gh := &GitHubFormatter{}
-	return gh.FormatSingle(diff, opts)
-}
-
-// Format renders differences in Gitea CI format (GitHub Actions compatible).
-func (f *GiteaFormatter) Format(diffs []Difference, opts *FormatOptions) string {
-	// Gitea uses GitHub Actions compatible format
-	gh := &GitHubFormatter{}
-	return gh.Format(diffs, opts)
-}
-
-// FormatAll delegates to GitHubFormatter for directory mode support.
-func (f *GiteaFormatter) FormatAll(groups []DiffGroup, opts *FormatOptions) string {
-	gh := &GitHubFormatter{}
-	return gh.FormatAll(groups, opts)
+//
+// Behaviour is inherited from GitHubFormatter via struct embedding;
+// FormatSingle, Format, and FormatAll are promoted methods.
+type GiteaFormatter struct {
+	GitHubFormatter
 }
 
 // JSONFormatter renders differences as machine-readable JSON.

--- a/pkg/diffyml/formatter.go
+++ b/pkg/diffyml/formatter.go
@@ -89,7 +89,10 @@ func FormatterByName(name string) (Formatter, error) {
 	case "gitlab":
 		return &GitLabFormatter{}, nil
 	case "gitea":
-		return &GiteaFormatter{}, nil
+		// Gitea Actions accepts the GitHub Actions workflow command syntax
+		// (gitea/gitea#23722). It silently ignores annotations in the UI,
+		// but the output is parseable in raw build logs.
+		return &GitHubFormatter{}, nil
 	case "json":
 		return &JSONFormatter{}, nil
 	case "json-patch":
@@ -571,17 +574,6 @@ func (f *GitLabFormatter) FormatAll(groups []DiffGroup, _ *FormatOptions) string
 
 	sb.WriteString("]\n")
 	return sb.String()
-}
-
-// GiteaFormatter renders output compatible with Gitea CI/CD.
-// Uses GitHub Actions compatible format. Note: Gitea Actions silently ignores
-// workflow command annotations (see gitea/gitea#23722), so annotations may not
-// appear in the Gitea UI. The output is still valid for log parsing.
-//
-// Behaviour is inherited from GitHubFormatter via struct embedding;
-// FormatSingle, Format, and FormatAll are promoted methods.
-type GiteaFormatter struct {
-	GitHubFormatter
 }
 
 // JSONFormatter renders differences as machine-readable JSON.

--- a/pkg/diffyml/formatter_test.go
+++ b/pkg/diffyml/formatter_test.go
@@ -580,21 +580,43 @@ func TestGitLabFormatter_MultipleDiffs(t *testing.T) {
 	}
 }
 
-func TestGiteaFormatter_GitHubCompatible(t *testing.T) {
+func TestFormatterByName_GiteaIsGitHubCompatible(t *testing.T) {
 	giteaF, _ := FormatterByName("gitea")
 	githubF, _ := FormatterByName("github")
-	opts := DefaultFormatOptions()
 
+	if _, ok := giteaF.(*GitHubFormatter); !ok {
+		t.Errorf(`FormatterByName("gitea") should return *GitHubFormatter, got %T`, giteaF)
+	}
+	if _, ok := giteaF.(StructuredFormatter); !ok {
+		t.Fatal(`FormatterByName("gitea") should implement StructuredFormatter`)
+	}
+
+	opts := DefaultFormatOptions()
 	diffs := []Difference{
 		{Path: DiffPath{"config", "value"}, Type: DiffModified, From: "old", To: "new"},
 	}
+	if giteaF.Format(diffs, opts) != githubF.Format(diffs, opts) {
+		t.Error("gitea output should match github output")
+	}
 
-	giteaOutput := giteaF.Format(diffs, opts)
-	githubOutput := githubF.Format(diffs, opts)
-
-	// Gitea should produce GitHub-compatible output
-	if giteaOutput != githubOutput {
-		t.Errorf("Gitea output should match GitHub output\nGitea: %s\nGitHub: %s", giteaOutput, githubOutput)
+	groups := []DiffGroup{
+		{
+			FilePath: "deploy.yaml",
+			Diffs: []Difference{
+				{Path: DiffPath{"key"}, Type: DiffModified, From: "old", To: "new"},
+			},
+		},
+		{
+			FilePath: "service.yaml",
+			Diffs: []Difference{
+				{Path: DiffPath{"port"}, Type: DiffAdded, To: 8080},
+			},
+		},
+	}
+	giteaAll := giteaF.(StructuredFormatter).FormatAll(groups, opts)
+	githubAll := githubF.(StructuredFormatter).FormatAll(groups, opts)
+	if giteaAll != githubAll {
+		t.Errorf("gitea FormatAll should match github FormatAll\nGitea:  %s\nGitHub: %s", giteaAll, githubAll)
 	}
 }
 
@@ -1638,7 +1660,6 @@ func TestFormatSingle_AllFormatters(t *testing.T) {
 		"brief":   &BriefFormatter{},
 		"github":  &GitHubFormatter{},
 		"gitlab":  &GitLabFormatter{},
-		"gitea":   &GiteaFormatter{},
 	}
 
 	for name, f := range formatters {
@@ -1913,42 +1934,6 @@ func TestGitHubFormatter_FormatAll_AnnotationLimitsAcrossGroups(t *testing.T) {
 	}
 	if containsSubstr(lastLine, "file=") {
 		t.Errorf("summary annotation should not include file= parameter, got: %s", lastLine)
-	}
-}
-
-func TestGiteaFormatter_FormatAll(t *testing.T) {
-	giteaF := &GiteaFormatter{}
-	githubF := &GitHubFormatter{}
-	opts := DefaultFormatOptions()
-
-	groups := []DiffGroup{
-		{
-			FilePath: "deploy.yaml",
-			Diffs: []Difference{
-				{Path: DiffPath{"key"}, Type: DiffModified, From: "old", To: "new"},
-			},
-		},
-		{
-			FilePath: "service.yaml",
-			Diffs: []Difference{
-				{Path: DiffPath{"port"}, Type: DiffAdded, To: 8080},
-			},
-		},
-	}
-
-	giteaOutput := giteaF.FormatAll(groups, opts)
-	githubOutput := githubF.FormatAll(groups, opts)
-
-	if giteaOutput != githubOutput {
-		t.Errorf("Gitea FormatAll should match GitHub FormatAll\nGitea:  %s\nGitHub: %s", giteaOutput, githubOutput)
-	}
-}
-
-func TestGiteaFormatter_ImplementsStructuredFormatter(t *testing.T) {
-	var f Formatter = &GiteaFormatter{}
-	_, ok := f.(StructuredFormatter)
-	if !ok {
-		t.Fatal("GiteaFormatter should implement StructuredFormatter")
 	}
 }
 


### PR DESCRIPTION
## What

Remove the public `GiteaFormatter` type entirely. `FormatterByName("gitea")` now returns `&GitHubFormatter{}` directly. The `--output gitea` CLI value is preserved.

## Why

Continuing the architecture audit. Three layers of evidence:

1. **No native Gitea annotation format exists.** Per Gitea's docs (https://docs.gitea.com/usage/actions/comparison), workflow-command annotations like `::error::`, `::warning::`, `::notice::` are **explicitly unsupported and silently ignored** by Gitea Actions. The referenced upstream issue [gitea/gitea#23722](https://github.com/go-gitea/gitea/issues/23722) has been open for 3 years with no fix.

2. **Gitea Actions is designed to be GitHub-compatible at the workflow syntax level.** From Gitea's own docs: *"Gitea Actions is designed to be compatible with GitHub Actions wherever possible."* So GitHub-compatible output is genuinely the right wire format — Gitea just doesn't render it in the UI.

3. **The `GiteaFormatter` type was a 1:1 wrapper** that already produced byte-identical output to `GitHubFormatter` (via the original three forwarding methods, then briefly via embedding in the previous commit on this branch). Removing it deletes a typed indirection that earned no behavioural difference.

A user who picks `--output gitea` gets exactly the same bytes as before — the only thing that changes is that there is one fewer public type in `pkg/diffyml`.

## How

- `FormatterByName("gitea")` returns `&GitHubFormatter{}`. The case has a comment explaining the upstream constraint.
- `type GiteaFormatter struct { ... }` deleted.
- `doc.go` updated: now lists "Seven built-in formatters", with a note under `[GitHubFormatter]` that `"gitea"` is also accepted as a name.
- Tests:
  - `TestGiteaFormatter_GitHubCompatible` folded into `TestFormatterByName_GiteaIsGitHubCompatible`, which asserts (a) `FormatterByName("gitea")` returns `*GitHubFormatter`, (b) the result implements `StructuredFormatter`, (c) `Format` output matches GitHub, (d) `FormatAll` output matches GitHub.
  - `TestGiteaFormatter_FormatAll` and `TestGiteaFormatter_ImplementsStructuredFormatter` deleted (subsumed).
  - `"gitea"` entry removed from the `FormatSingle` iteration map — it would have been a duplicate `*GitHubFormatter`.
- Existing fixture test `testdata/fixtures/017-output-gitea` continues to pass unchanged (output is byte-identical).

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally (100% coverage, 0 lint issues, govulncheck clean)
- [x] New/changed behavior covered by tests (consolidated contract test in `formatter_test.go`)
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

- **Public API change**: `GiteaFormatter` type is removed. There is no production code outside this repo that I'm aware of that imports it. Anyone using `--output gitea` from the CLI is unaffected; only Go callers constructing `&diffyml.GiteaFormatter{}` directly would need to switch to `&diffyml.GitHubFormatter{}` (or call `diffyml.FormatterByName("gitea")`).
- The branch initially landed an embedding approach (`type GiteaFormatter struct { GitHubFormatter }`); after a review question about whether Gitea actually uses GitHub's format, I verified Gitea's docs and decided full removal is more honest than wrapping a type that contributes nothing. Both commits are kept on the branch for review history; squash-merge will collapse them.