### PR TITLE
fix: set COSIGN_EXPERIMENTAL=1 for OCI 1.1 referrers signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,7 @@ jobs:
         env:
           IMAGE: ${{ steps.manifest.outputs.image }}
           DIGEST: ${{ steps.manifest.outputs.digest }}
+          COSIGN_EXPERIMENTAL: "1"
         run: |
           cosign sign --yes --registry-referrers-mode=oci-1-1 "${IMAGE}@${DIGEST}"
 


### PR DESCRIPTION
## What

Set `COSIGN_EXPERIMENTAL=1` on the `Sign manifest with cosign` step so `cosign sign --registry-referrers-mode=oci-1-1` can run.

## Why

The `v1.6.0` release ([run](https://github.com/szhekpisov/diffyml/actions/runs/25402427495/job/74505303176)) failed with:

```
Error: invalid argument "oci-1-1" for "--registry-referrers-mode" flag:
in order to use mode "oci-1-1", you must set COSIGN_EXPERIMENTAL=1
```

cosign v3.x keeps the OCI 1.1 referrers mode behind `COSIGN_EXPERIMENTAL=1` because the on-registry layout from the OCI 1.1 referrers spec is still considered evolving. The `--registry-referrers-mode=oci-1-1` flag was introduced in #120 but never exercised end-to-end until v1.6.0, so the missing env var went unnoticed (the PR description even called out that verification required cutting a release).

## How

Add `COSIGN_EXPERIMENTAL: "1"` to the step's `env` block. One-line change.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally — N/A, CI/workflow-only change
- [x] New/changed behavior covered by tests — N/A, verified by re-running release
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%) — N/A
- [x] No new dependencies (or justified)

## Notes for reviewers

- After merge, the existing `v1.6.0` tag needs to be moved (or a new tag cut) for the release workflow to actually exercise the fix; the failed run cannot be retried because the workflow file on the tagged commit doesn't include this change.
- Alternative considered: drop `--registry-referrers-mode=oci-1-1` entirely and revert to default sidecar-tag signing. That would re-introduce the confusing `sha256-…` rows on the GHCR package page that #120 set out to remove, so this fix preserves that cleanup.