### PR TITLE
feat: add .deb/.rpm/.apk Linux packages with SBOMs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,6 +163,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.26.2"
+          cache: false
 
       - name: Install goreleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
       docker: ${{ steps.filter.outputs.docker }}
+      packaging: ${{ steps.filter.outputs.packaging }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -34,6 +35,9 @@ jobs:
               - 'go.sum'
             docker:
               - 'Dockerfile*'
+            packaging:
+              - '.goreleaser.yaml'
+              - 'Makefile'
 
   hadolint:
     needs: changes
@@ -146,3 +150,25 @@ jobs:
           fi
 
           echo "All coverage thresholds passed"
+
+  packages:
+    needs: changes
+    if: needs.changes.outputs.packaging == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.2"
+
+      - name: Install goreleaser
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          version: "~> v2"
+          install-only: true
+
+      - name: Build and verify Linux packages
+        run: make packages-verify

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/public/
 docs/resources/
 docs/.hugo_build.lock
 docs/themes/
+
+# goreleaser snapshot output
+/dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,11 +27,11 @@ nfpms:
     package_name: diffyml
     vendor: Sergei Zhekpisov
     homepage: https://github.com/szhekpisov/diffyml
-    maintainer: Sergei Zhekpisov <zhekpisov@gmail.com>
+    maintainer: Sergei Zhekpisov <87662520+szhekpisov@users.noreply.github.com>
     description: |-
       Structural diff tool for YAML files.
-      Compares YAML files semantically — understanding key ordering, list
-      identity, multi-document streams, and Kubernetes resources — with
+      Compares YAML files semantically (understanding key ordering, list
+      identity, multi-document streams, and Kubernetes resources) with
       multiple output formats for CI integration.
     license: MIT
     formats:
@@ -41,9 +41,10 @@ nfpms:
     bindir: /usr/bin
     section: utils
     priority: optional
+    mtime: "{{ .CommitDate }}"
     contents:
       - src: ./LICENSE
-        dst: /usr/share/doc/diffyml/LICENSE
+        dst: /usr/share/doc/diffyml/copyright
       - src: ./README.md
         dst: /usr/share/doc/diffyml/README.md
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,11 +22,41 @@ archives:
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
+nfpms:
+  - id: packages
+    package_name: diffyml
+    vendor: Sergei Zhekpisov
+    homepage: https://github.com/szhekpisov/diffyml
+    maintainer: Sergei Zhekpisov <zhekpisov@gmail.com>
+    description: |-
+      Structural diff tool for YAML files.
+      Compares YAML files semantically — understanding key ordering, list
+      identity, multi-document streams, and Kubernetes resources — with
+      multiple output formats for CI integration.
+    license: MIT
+    formats:
+      - deb
+      - rpm
+      - apk
+    bindir: /usr/bin
+    section: utils
+    priority: optional
+    contents:
+      - src: ./LICENSE
+        dst: /usr/share/doc/diffyml/LICENSE
+      - src: ./README.md
+        dst: /usr/share/doc/diffyml/README.md
+
 checksum:
   name_template: checksums.txt
 
 sboms:
-  - artifacts: archive
+  - id: archive
+    artifacts: archive
+    documents:
+      - "${artifact}.spdx.json"
+  - id: package
+    artifacts: package
     documents:
       - "${artifact}.spdx.json"
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,13 @@ nfpms:
     contents:
       - src: ./LICENSE
         dst: /usr/share/doc/diffyml/copyright
+        packager: deb
+      - src: ./LICENSE
+        dst: /usr/share/licenses/diffyml/LICENSE
+        packager: rpm
+      - src: ./LICENSE
+        dst: /usr/share/licenses/diffyml/LICENSE
+        packager: apk
       - src: ./README.md
         dst: /usr/share/doc/diffyml/README.md
 

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ fixture: build
 packages-snapshot:
 	@command -v goreleaser >/dev/null 2>&1 || { echo "goreleaser not installed (brew install goreleaser)"; exit 1; }
 	@command -v docker >/dev/null 2>&1 || { echo "docker not installed or not running"; exit 1; }
-	goreleaser release --snapshot --clean --skip=sign,sbom
+	goreleaser release --snapshot --clean --skip=sign,sbom,docker
 	@echo ""
 	@echo "=== Package layout ==="
 	@echo "--- .deb (expect copyright at /usr/share/doc/) ---"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build coverage check-coverage check-doc bench bench-cpu bench-mem bench-compare govulncheck golangci-lint security test e2e fmt lint vet ci fixture changelog fuzz fuzz-long mutation mutation-dry docs-gen docs-check docs-serve docs-build
+.PHONY: build coverage check-coverage check-doc bench bench-cpu bench-mem bench-compare govulncheck golangci-lint security test e2e fmt lint vet ci fixture changelog fuzz fuzz-long mutation mutation-dry docs-gen docs-check docs-serve docs-build packages-snapshot packages-verify
 
 BIN = /tmp/diffyml-dev
 
@@ -159,3 +159,47 @@ fixture: build
 		eval $(BIN) --color off --set-exit-code $$PARAMS "$$DIR/file1.yaml" "$$DIR/file2.yaml"; \
 	fi; \
 	RC=$$?; echo ""; echo "exit code: $$RC"
+
+# Build .deb/.rpm/.apk packages locally via goreleaser snapshot mode and
+# inspect their layout. Skips signing/SBOMs (those need release credentials).
+# Requires goreleaser and Docker.
+packages-snapshot:
+	@command -v goreleaser >/dev/null 2>&1 || { echo "goreleaser not installed (brew install goreleaser)"; exit 1; }
+	@command -v docker >/dev/null 2>&1 || { echo "docker not installed or not running"; exit 1; }
+	goreleaser release --snapshot --clean --skip=sign,sbom
+	@echo ""
+	@echo "=== Package layout ==="
+	@echo "--- .deb (expect copyright at /usr/share/doc/) ---"
+	@docker run --rm -v "$$PWD/dist:/d" debian:stable-slim sh -c \
+		'dpkg -c /d/diffyml_*_linux_amd64.deb | grep -E "copyright|usr/bin/diffyml|README"'
+	@echo "--- .rpm (expect LICENSE at /usr/share/licenses/) ---"
+	@docker run --rm -v "$$PWD/dist:/d" rockylinux:9 sh -c \
+		'rpm -qlp /d/diffyml_*_linux_amd64.rpm | grep -E "LICENSE|usr/bin/diffyml|README"'
+	@echo "--- .apk (expect LICENSE at /usr/share/licenses/) ---"
+	@tar -tzf dist/diffyml_*_linux_amd64.apk | grep -E 'LICENSE|usr/bin/diffyml|README'
+
+# Install the snapshot packages in real distro containers and verify the
+# binary works. Auto-detects host architecture so it works on both x86_64
+# and Apple Silicon. Depends on packages-snapshot.
+packages-verify: packages-snapshot
+	@HOST_ARCH=$$(uname -m); \
+	case "$$HOST_ARCH" in \
+		x86_64|amd64)  PKG_ARCH=amd64 ;; \
+		aarch64|arm64) PKG_ARCH=arm64 ;; \
+		*) echo "unsupported host arch: $$HOST_ARCH"; exit 1 ;; \
+	esac; \
+	echo ""; \
+	echo "=== Install verification (host arch: $$PKG_ARCH) ==="; \
+	echo "--- Ubuntu 24.04 (.deb) ---"; \
+	docker run --rm -v "$$PWD/dist:/pkg" ubuntu:24.04 bash -c \
+		"dpkg -i /pkg/diffyml_*_linux_$${PKG_ARCH}.deb && diffyml --version" || exit 1; \
+	echo ""; \
+	echo "--- Fedora latest (.rpm) ---"; \
+	docker run --rm -v "$$PWD/dist:/pkg" fedora:latest bash -c \
+		"rpm -i /pkg/diffyml_*_linux_$${PKG_ARCH}.rpm && diffyml --version" || exit 1; \
+	echo ""; \
+	echo "--- Alpine latest (.apk) ---"; \
+	docker run --rm -v "$$PWD/dist:/pkg" alpine:latest sh -c \
+		"apk add --allow-untrusted /pkg/diffyml_*_linux_$${PKG_ARCH}.apk && diffyml --version" || exit 1; \
+	echo ""; \
+	echo "All package install tests passed"

--- a/README.md
+++ b/README.md
@@ -92,9 +92,29 @@ Make sure `$GOPATH/bin` is in your `PATH`:
 export PATH="$(go env GOPATH)/bin:$PATH"
 ```
 
+### Install script (Linux / macOS)
+
+```bash
+curl -fsSL https://szhekpisov.github.io/diffyml/install.sh | sh
+```
+
+Detects your OS and architecture, downloads the matching release archive, verifies its SHA256 against the signed `checksums.txt`, and installs to `/usr/local/bin/diffyml`. Customizable via env vars:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. |
+| `INSTALL_DIR` | `/usr/local/bin` | Falls back to `sudo` if the directory isn't writable. |
+| `VERIFY` | `sha256` | Set `cosign` to verify the cosign signature on `checksums.txt` first (requires `cosign` in `PATH`), or `none` to skip verification. |
+
+```bash
+# Pin a version, install into ~/bin, verify cosign signature too:
+DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
+  sh -c "$(curl -fsSL https://szhekpisov.github.io/diffyml/install.sh)"
+```
+
 ### Direct binary download
 
-Pre-built binaries for Linux and macOS (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases). Download, extract, and move onto your `PATH`:
+If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64):
 
 ```bash
 VERSION=1.6.0  # check the releases page for the latest

--- a/README.md
+++ b/README.md
@@ -112,21 +112,6 @@ DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
   sh -c "$(curl -fsSL https://szhekpisov.github.io/diffyml/install.sh)"
 ```
 
-### Direct binary download
-
-If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64):
-
-```bash
-VERSION=1.6.0  # check the releases page for the latest
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
-  | tar -xz
-sudo mv diffyml /usr/local/bin/
-```
-
-See [Verifying Releases](#verifying-releases) below to check signatures and provenance before installing.
-
 ### Linux packages (`.deb` / `.rpm` / `.apk`)
 
 Native packages for Debian/Ubuntu, RHEL/Fedora, and Alpine (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases):
@@ -146,6 +131,21 @@ sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
 ```
 
 The binary is installed to `/usr/bin/diffyml`.
+
+### Direct binary download
+
+If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64):
+
+```bash
+VERSION=1.6.0  # check the releases page for the latest
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
+  | tar -xz
+sudo mv diffyml /usr/local/bin/
+```
+
+See [Verifying Releases](#verifying-releases) below to check signatures and provenance before installing.
 
 ### Docker
 

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ Detects your OS and architecture, downloads the matching release archive, verifi
 
 | Variable | Default | Notes |
 |---|---|---|
-| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. **Recommended in CI** — avoids the unauthenticated GitHub API call (60 req/hr per IP) used to resolve the latest tag. |
+| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.1`. **Recommended in CI** — avoids the unauthenticated GitHub API call (60 req/hr per IP) used to resolve the latest tag. |
 | `INSTALL_DIR` | `/usr/local/bin` | Falls back to `sudo` if the directory isn't writable. |
 | `VERIFY` | `sha256` | Set `cosign` to verify the cosign signature on `checksums.txt` first (requires `cosign` in `PATH`), or `none` to skip verification. |
 | `GITHUB_TOKEN` | unset | If set, used to authenticate the GitHub API call when resolving the latest version. Useful on shared CI egress IPs. |
 
 ```bash
 # Pin a version, install into ~/bin, verify cosign signature too:
-DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
+DIFFYML_VERSION=1.6.1 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
   sh -c "$(curl -fsSL https://szhekpisov.github.io/diffyml/install.sh)"
 ```
 
@@ -119,16 +119,16 @@ Native packages for Debian/Ubuntu, RHEL/Fedora, and Alpine (amd64 and arm64) are
 
 ```bash
 # Debian / Ubuntu
-curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
-sudo dpkg -i diffyml_1.6.0_linux_amd64.deb
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.1/diffyml_1.6.1_linux_amd64.deb"
+sudo dpkg -i diffyml_1.6.1_linux_amd64.deb
 
 # RHEL / Fedora / openSUSE
-curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
-sudo rpm -i diffyml_1.6.0_linux_amd64.rpm
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.1/diffyml_1.6.1_linux_amd64.rpm"
+sudo rpm -i diffyml_1.6.1_linux_amd64.rpm
 
 # Alpine
-curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
-sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.1/diffyml_1.6.1_linux_amd64.apk"
+sudo apk add --allow-untrusted diffyml_1.6.1_linux_amd64.apk
 ```
 
 The binary is installed to `/usr/bin/diffyml`.
@@ -138,7 +138,7 @@ The binary is installed to `/usr/bin/diffyml`.
 If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64):
 
 ```bash
-VERSION=1.6.0  # check the releases page for the latest
+VERSION=1.6.1  # check the releases page for the latest
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 curl -fL "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ Detects your OS and architecture, downloads the matching release archive, verifi
 
 | Variable | Default | Notes |
 |---|---|---|
-| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. |
+| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. **Recommended in CI** — avoids the unauthenticated GitHub API call (60 req/hr per IP) used to resolve the latest tag. |
 | `INSTALL_DIR` | `/usr/local/bin` | Falls back to `sudo` if the directory isn't writable. |
 | `VERIFY` | `sha256` | Set `cosign` to verify the cosign signature on `checksums.txt` first (requires `cosign` in `PATH`), or `none` to skip verification. |
+| `GITHUB_TOKEN` | unset | If set, used to authenticate the GitHub API call when resolving the latest version. Useful on shared CI egress IPs. |
 
 ```bash
 # Pin a version, install into ~/bin, verify cosign signature too:
@@ -114,19 +115,19 @@ DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
 
 ### Linux packages (`.deb` / `.rpm` / `.apk`)
 
-Native packages for Debian/Ubuntu, RHEL/Fedora, and Alpine (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases):
+Native packages for Debian/Ubuntu, RHEL/Fedora, and Alpine (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases). All package archives are listed in the cosign-signed `checksums.txt`, so you can verify before installing — see [Verifying Releases](#verifying-releases). The .apk uses `--allow-untrusted` because nfpm-built apks aren't GPG-signed; verify the SHA256 from `checksums.txt` instead.
 
 ```bash
 # Debian / Ubuntu
-curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
 sudo dpkg -i diffyml_1.6.0_linux_amd64.deb
 
 # RHEL / Fedora / openSUSE
-curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
 sudo rpm -i diffyml_1.6.0_linux_amd64.rpm
 
 # Alpine
-curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
 sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
 ```
 
@@ -140,7 +141,7 @@ If you'd rather not pipe a script to `sh`, the same archives are attached to eve
 VERSION=1.6.0  # check the releases page for the latest
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
+curl -fL "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
   | tar -xz
 sudo mv diffyml /usr/local/bin/
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,41 @@ Make sure `$GOPATH/bin` is in your `PATH`:
 export PATH="$(go env GOPATH)/bin:$PATH"
 ```
 
+### Direct binary download
+
+Pre-built binaries for Linux and macOS (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases). Download, extract, and move onto your `PATH`:
+
+```bash
+VERSION=1.6.0  # check the releases page for the latest
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
+  | tar -xz
+sudo mv diffyml /usr/local/bin/
+```
+
+See [Verifying Releases](#verifying-releases) below to check signatures and provenance before installing.
+
+### Linux packages (`.deb` / `.rpm` / `.apk`)
+
+Native packages for Debian/Ubuntu, RHEL/Fedora, and Alpine (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases):
+
+```bash
+# Debian / Ubuntu
+curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
+sudo dpkg -i diffyml_1.6.0_linux_amd64.deb
+
+# RHEL / Fedora / openSUSE
+curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
+sudo rpm -i diffyml_1.6.0_linux_amd64.rpm
+
+# Alpine
+curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
+sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
+```
+
+The binary is installed to `/usr/bin/diffyml`.
+
 ### Docker
 
 Multi-arch images (linux/amd64, linux/arm64) are published to GitHub Container Registry:

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -37,9 +37,32 @@ docker run --rm -v "$PWD:/work" -w /work ghcr.io/szhekpisov/diffyml:latest old.y
 
 Images are built from a [distroless](https://github.com/GoogleContainerTools/distroless) base and run as a non-root user. Use `:latest` or pin to a specific version (e.g. `:1.5.25`).
 
+## Install script (Linux / macOS)
+
+```bash
+curl -fsSL https://szhekpisov.github.io/diffyml/install.sh | sh
+```
+
+Detects your OS and architecture, downloads the matching release archive, verifies its SHA256 against the signed `checksums.txt`, and installs the binary to `/usr/local/bin/diffyml`.
+
+Environment variables:
+
+| Variable | Default | Notes |
+|---|---|---|
+| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. |
+| `INSTALL_DIR` | `/usr/local/bin` | Falls back to `sudo` if the directory isn't writable. |
+| `VERIFY` | `sha256` | Use `cosign` to verify the cosign signature on `checksums.txt` first (requires `cosign` in `PATH`), or `none` to skip verification. |
+
+Example pinning a version, installing into `~/bin`, and adding cosign verification:
+
+```bash
+DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
+  sh -c "$(curl -fsSL https://szhekpisov.github.io/diffyml/install.sh)"
+```
+
 ## Direct binary download
 
-Pre-built binaries for Linux and macOS (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases). Download, extract, and move onto your `PATH`:
+If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64). Download, extract, and move onto your `PATH`:
 
 ```bash
 VERSION=1.6.0  # check the releases page for the latest

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -49,7 +49,7 @@ Environment variables:
 
 | Variable | Default | Notes |
 |---|---|---|
-| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. **Recommended in CI** — avoids the unauthenticated GitHub API call (60 req/hr per IP) used to resolve the latest tag. |
+| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.1`. **Recommended in CI** — avoids the unauthenticated GitHub API call (60 req/hr per IP) used to resolve the latest tag. |
 | `INSTALL_DIR` | `/usr/local/bin` | Falls back to `sudo` if the directory isn't writable. |
 | `VERIFY` | `sha256` | Use `cosign` to verify the cosign signature on `checksums.txt` first (requires `cosign` in `PATH`), or `none` to skip verification. |
 | `GITHUB_TOKEN` | unset | If set, used to authenticate the GitHub API call when resolving the latest version. Useful on shared CI egress IPs. |
@@ -57,7 +57,7 @@ Environment variables:
 Example pinning a version, installing into `~/bin`, and adding cosign verification:
 
 ```bash
-DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
+DIFFYML_VERSION=1.6.1 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
   sh -c "$(curl -fsSL https://szhekpisov.github.io/diffyml/install.sh)"
 ```
 
@@ -67,16 +67,16 @@ Native `.deb`, `.rpm`, and `.apk` packages for amd64 and arm64 are attached to e
 
 ```bash
 # Debian / Ubuntu
-curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
-sudo dpkg -i diffyml_1.6.0_linux_amd64.deb
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.1/diffyml_1.6.1_linux_amd64.deb"
+sudo dpkg -i diffyml_1.6.1_linux_amd64.deb
 
 # RHEL / Fedora / openSUSE
-curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
-sudo rpm -i diffyml_1.6.0_linux_amd64.rpm
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.1/diffyml_1.6.1_linux_amd64.rpm"
+sudo rpm -i diffyml_1.6.1_linux_amd64.rpm
 
 # Alpine
-curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
-sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.1/diffyml_1.6.1_linux_amd64.apk"
+sudo apk add --allow-untrusted diffyml_1.6.1_linux_amd64.apk
 ```
 
 ## Direct binary download
@@ -84,7 +84,7 @@ sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
 If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64). Download, extract, and move onto your `PATH`:
 
 ```bash
-VERSION=1.6.0  # check the releases page for the latest
+VERSION=1.6.1  # check the releases page for the latest
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 curl -fL "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -37,9 +37,38 @@ docker run --rm -v "$PWD:/work" -w /work ghcr.io/szhekpisov/diffyml:latest old.y
 
 Images are built from a [distroless](https://github.com/GoogleContainerTools/distroless) base and run as a non-root user. Use `:latest` or pin to a specific version (e.g. `:1.5.25`).
 
-## Release binaries
+## Direct binary download
 
-Pre-built binaries for Linux, macOS, and Windows are published on the [releases page](https://github.com/szhekpisov/diffyml/releases). Download the archive matching your platform, extract, and place `diffyml` on your `PATH`.
+Pre-built binaries for Linux and macOS (amd64 and arm64) are attached to every [release](https://github.com/szhekpisov/diffyml/releases). Download, extract, and move onto your `PATH`:
+
+```bash
+VERSION=1.6.0  # check the releases page for the latest
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
+  | tar -xz
+sudo mv diffyml /usr/local/bin/
+```
+
+Archives are named `diffyml_<VERSION>_<os>_<arch>.tar.gz`. See [Verifying releases](#verifying-releases) to check signatures and provenance before installing.
+
+## Linux packages
+
+Native `.deb`, `.rpm`, and `.apk` packages for amd64 and arm64 are attached to every [release](https://github.com/szhekpisov/diffyml/releases). The binary installs to `/usr/bin/diffyml`.
+
+```bash
+# Debian / Ubuntu
+curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
+sudo dpkg -i diffyml_1.6.0_linux_amd64.deb
+
+# RHEL / Fedora / openSUSE
+curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
+sudo rpm -i diffyml_1.6.0_linux_amd64.rpm
+
+# Alpine
+curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
+sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
+```
 
 ## From source
 

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -49,9 +49,10 @@ Environment variables:
 
 | Variable | Default | Notes |
 |---|---|---|
-| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. |
+| `DIFFYML_VERSION` | latest release | Pin a specific version, e.g. `1.6.0`. **Recommended in CI** — avoids the unauthenticated GitHub API call (60 req/hr per IP) used to resolve the latest tag. |
 | `INSTALL_DIR` | `/usr/local/bin` | Falls back to `sudo` if the directory isn't writable. |
 | `VERIFY` | `sha256` | Use `cosign` to verify the cosign signature on `checksums.txt` first (requires `cosign` in `PATH`), or `none` to skip verification. |
+| `GITHUB_TOKEN` | unset | If set, used to authenticate the GitHub API call when resolving the latest version. Useful on shared CI egress IPs. |
 
 Example pinning a version, installing into `~/bin`, and adding cosign verification:
 
@@ -62,19 +63,19 @@ DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
 
 ## Linux packages
 
-Native `.deb`, `.rpm`, and `.apk` packages for amd64 and arm64 are attached to every [release](https://github.com/szhekpisov/diffyml/releases). The binary installs to `/usr/bin/diffyml`.
+Native `.deb`, `.rpm`, and `.apk` packages for amd64 and arm64 are attached to every [release](https://github.com/szhekpisov/diffyml/releases). The binary installs to `/usr/bin/diffyml`. All package archives are listed in the cosign-signed `checksums.txt`, so you can verify before installing — see [Verifying releases](#verifying-releases). The .apk uses `--allow-untrusted` because nfpm-built apks aren't GPG-signed; verify the SHA256 from `checksums.txt` instead.
 
 ```bash
 # Debian / Ubuntu
-curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.deb"
 sudo dpkg -i diffyml_1.6.0_linux_amd64.deb
 
 # RHEL / Fedora / openSUSE
-curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.rpm"
 sudo rpm -i diffyml_1.6.0_linux_amd64.rpm
 
 # Alpine
-curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
+curl -fLO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
 sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
 ```
 
@@ -86,7 +87,7 @@ If you'd rather not pipe a script to `sh`, the same archives are attached to eve
 VERSION=1.6.0  # check the releases page for the latest
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
+curl -fL "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
   | tar -xz
 sudo mv diffyml /usr/local/bin/
 ```

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -60,21 +60,6 @@ DIFFYML_VERSION=1.6.0 INSTALL_DIR="$HOME/bin" VERIFY=cosign \
   sh -c "$(curl -fsSL https://szhekpisov.github.io/diffyml/install.sh)"
 ```
 
-## Direct binary download
-
-If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64). Download, extract, and move onto your `PATH`:
-
-```bash
-VERSION=1.6.0  # check the releases page for the latest
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
-curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
-  | tar -xz
-sudo mv diffyml /usr/local/bin/
-```
-
-Archives are named `diffyml_<VERSION>_<os>_<arch>.tar.gz`. See [Verifying releases](#verifying-releases) to check signatures and provenance before installing.
-
 ## Linux packages
 
 Native `.deb`, `.rpm`, and `.apk` packages for amd64 and arm64 are attached to every [release](https://github.com/szhekpisov/diffyml/releases). The binary installs to `/usr/bin/diffyml`.
@@ -92,6 +77,21 @@ sudo rpm -i diffyml_1.6.0_linux_amd64.rpm
 curl -LO "https://github.com/szhekpisov/diffyml/releases/download/v1.6.0/diffyml_1.6.0_linux_amd64.apk"
 sudo apk add --allow-untrusted diffyml_1.6.0_linux_amd64.apk
 ```
+
+## Direct binary download
+
+If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64). Download, extract, and move onto your `PATH`:
+
+```bash
+VERSION=1.6.0  # check the releases page for the latest
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -L "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
+  | tar -xz
+sudo mv diffyml /usr/local/bin/
+```
+
+Archives are named `diffyml_<VERSION>_<os>_<arch>.tar.gz`. See [Verifying releases](#verifying-releases) to check signatures and provenance before installing.
 
 ## From source
 

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -8,13 +8,119 @@
 #   DIFFYML_VERSION  version to install, e.g. 1.6.0 (default: latest release)
 #   INSTALL_DIR      install directory (default: /usr/local/bin)
 #   VERIFY           verification mode: sha256 (default), cosign, none
+#   GITHUB_TOKEN     optional, used for the GitHub API call when resolving
+#                    the latest version. Pin DIFFYML_VERSION in CI to avoid
+#                    the API call entirely.
+#
+# The whole script is wrapped in main() and invoked at EOF so that an
+# interrupted `curl | sh` cannot execute a partially-downloaded script.
 
-set -eu
+main() {
+    set -eu
 
-REPO="szhekpisov/diffyml"
-DIFFYML_VERSION="${DIFFYML_VERSION:-}"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
-VERIFY="${VERIFY:-sha256}"
+    REPO="szhekpisov/diffyml"
+    DIFFYML_VERSION="${DIFFYML_VERSION:-}"
+    INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+    VERIFY="${VERIFY:-sha256}"
+
+    require curl
+    require tar
+    require uname
+
+    os=$(uname -s | tr '[:upper:]' '[:lower:]')
+    case "$os" in
+        linux|darwin) ;;
+        *) err "unsupported OS: $os (only linux and darwin are supported)" ;;
+    esac
+
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64|amd64)  arch=amd64 ;;
+        aarch64|arm64) arch=arm64 ;;
+        *) err "unsupported architecture: $arch (only amd64 and arm64 are supported)" ;;
+    esac
+
+    if [ -z "$DIFFYML_VERSION" ]; then
+        info "fetching latest version..."
+        DIFFYML_VERSION=$(
+            gh_api "https://api.github.com/repos/${REPO}/releases/latest" \
+                | grep '"tag_name"' \
+                | head -1 \
+                | cut -d'"' -f4
+        )
+        [ -n "$DIFFYML_VERSION" ] || err "could not determine latest version"
+    fi
+    DIFFYML_VERSION="${DIFFYML_VERSION#v}"
+
+    archive="diffyml_${DIFFYML_VERSION}_${os}_${arch}.tar.gz"
+    base_url="https://github.com/${REPO}/releases/download/v${DIFFYML_VERSION}"
+
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    info "downloading ${archive}..."
+    curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" \
+        || err "download failed: ${base_url}/${archive}"
+
+    case "$VERIFY" in
+        none)
+            info "skipping verification (VERIFY=none)"
+            ;;
+        sha256|cosign)
+            curl -fsSL -o "${tmpdir}/checksums.txt" "${base_url}/checksums.txt" \
+                || err "could not fetch checksums.txt"
+
+            if [ "$VERIFY" = cosign ]; then
+                require cosign
+                info "verifying cosign signature on checksums.txt..."
+                curl -fsSL -o "${tmpdir}/checksums.txt.sigstore.json" \
+                    "${base_url}/checksums.txt.sigstore.json" \
+                    || err "could not fetch cosign bundle"
+                cosign verify-blob "${tmpdir}/checksums.txt" \
+                    --bundle "${tmpdir}/checksums.txt.sigstore.json" \
+                    --certificate-identity-regexp "https://github.com/${REPO}/" \
+                    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+                    >/dev/null \
+                    || err "cosign verification failed"
+                info "cosign signature verified"
+            fi
+
+            info "verifying SHA256..."
+            expected=$(awk -v f="$archive" '$2 == f {print $1}' "${tmpdir}/checksums.txt")
+            [ -n "$expected" ] || err "no SHA256 entry for ${archive} in checksums.txt"
+            actual=$(sha256_of "${tmpdir}/${archive}")
+            [ "$actual" = "$expected" ] \
+                || err "SHA256 mismatch (expected $expected, got $actual)"
+            info "SHA256 verified"
+            ;;
+        *)
+            err "unknown VERIFY mode: $VERIFY (use sha256, cosign, or none)"
+            ;;
+    esac
+
+    info "extracting..."
+    tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
+    [ -f "${tmpdir}/diffyml" ] || err "diffyml binary not found in archive"
+    chmod +x "${tmpdir}/diffyml"
+
+    if mkdir -p "$INSTALL_DIR" 2>/dev/null && [ -w "$INSTALL_DIR" ]; then
+        mv "${tmpdir}/diffyml" "${INSTALL_DIR}/diffyml"
+    elif command -v sudo >/dev/null 2>&1; then
+        info "installing to ${INSTALL_DIR} (requires sudo)..."
+        sudo mkdir -p "$INSTALL_DIR"
+        sudo mv "${tmpdir}/diffyml" "${INSTALL_DIR}/diffyml"
+    else
+        err "cannot write to ${INSTALL_DIR} and sudo not available; set INSTALL_DIR"
+    fi
+
+    info ""
+    info "diffyml ${DIFFYML_VERSION} installed to ${INSTALL_DIR}/diffyml"
+
+    case ":${PATH}:" in
+        *":${INSTALL_DIR}:"*) ;;
+        *) info "note: ${INSTALL_DIR} is not in your PATH" ;;
+    esac
+}
 
 err() { printf 'error: %s\n' "$1" >&2; exit 1; }
 info() { printf '%s\n' "$1"; }
@@ -30,100 +136,12 @@ sha256_of() {
     fi
 }
 
-require curl
-require tar
-require uname
+gh_api() {
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" "$@"
+    else
+        curl -fsSL "$@"
+    fi
+}
 
-os=$(uname -s | tr '[:upper:]' '[:lower:]')
-case "$os" in
-    linux|darwin) ;;
-    *) err "unsupported OS: $os (only linux and darwin are supported)" ;;
-esac
-
-arch=$(uname -m)
-case "$arch" in
-    x86_64|amd64)    arch=amd64 ;;
-    aarch64|arm64)   arch=arm64 ;;
-    *) err "unsupported architecture: $arch (only amd64 and arm64 are supported)" ;;
-esac
-
-if [ -z "$DIFFYML_VERSION" ]; then
-    info "fetching latest version..."
-    DIFFYML_VERSION=$(
-        curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-            | grep '"tag_name"' \
-            | head -1 \
-            | cut -d'"' -f4
-    )
-    [ -n "$DIFFYML_VERSION" ] || err "could not determine latest version"
-fi
-DIFFYML_VERSION="${DIFFYML_VERSION#v}"
-
-archive="diffyml_${DIFFYML_VERSION}_${os}_${arch}.tar.gz"
-base_url="https://github.com/${REPO}/releases/download/v${DIFFYML_VERSION}"
-
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
-
-info "downloading ${archive}..."
-curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" \
-    || err "download failed: ${base_url}/${archive}"
-
-case "$VERIFY" in
-    none)
-        info "skipping verification (VERIFY=none)"
-        ;;
-    sha256|cosign)
-        curl -fsSL -o "${tmpdir}/checksums.txt" "${base_url}/checksums.txt" \
-            || err "could not fetch checksums.txt"
-
-        if [ "$VERIFY" = cosign ]; then
-            require cosign
-            info "verifying cosign signature on checksums.txt..."
-            curl -fsSL -o "${tmpdir}/checksums.txt.sigstore.json" \
-                "${base_url}/checksums.txt.sigstore.json" \
-                || err "could not fetch cosign bundle"
-            cosign verify-blob "${tmpdir}/checksums.txt" \
-                --bundle "${tmpdir}/checksums.txt.sigstore.json" \
-                --certificate-identity-regexp "https://github.com/${REPO}/" \
-                --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
-                >/dev/null 2>&1 \
-                || err "cosign verification failed"
-            info "cosign signature verified"
-        fi
-
-        info "verifying SHA256..."
-        expected=$(awk -v f="$archive" '$2 == f {print $1}' "${tmpdir}/checksums.txt")
-        [ -n "$expected" ] || err "no SHA256 entry for ${archive} in checksums.txt"
-        actual=$(sha256_of "${tmpdir}/${archive}")
-        [ "$actual" = "$expected" ] \
-            || err "SHA256 mismatch (expected $expected, got $actual)"
-        info "SHA256 verified"
-        ;;
-    *)
-        err "unknown VERIFY mode: $VERIFY (use sha256, cosign, or none)"
-        ;;
-esac
-
-info "extracting..."
-tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
-[ -f "${tmpdir}/diffyml" ] || err "diffyml binary not found in archive"
-chmod +x "${tmpdir}/diffyml"
-
-if mkdir -p "$INSTALL_DIR" 2>/dev/null && [ -w "$INSTALL_DIR" ]; then
-    mv "${tmpdir}/diffyml" "${INSTALL_DIR}/diffyml"
-elif command -v sudo >/dev/null 2>&1; then
-    info "installing to ${INSTALL_DIR} (requires sudo)..."
-    sudo mkdir -p "$INSTALL_DIR"
-    sudo mv "${tmpdir}/diffyml" "${INSTALL_DIR}/diffyml"
-else
-    err "cannot write to ${INSTALL_DIR} and sudo not available; set INSTALL_DIR"
-fi
-
-info ""
-info "diffyml ${DIFFYML_VERSION} installed to ${INSTALL_DIR}/diffyml"
-
-case ":${PATH}:" in
-    *":${INSTALL_DIR}:"*) ;;
-    *) info "note: ${INSTALL_DIR} is not in your PATH" ;;
-esac
+main "$@"

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -51,12 +51,15 @@ main() {
         [ -n "$DIFFYML_VERSION" ] || err "could not determine latest version"
     fi
     DIFFYML_VERSION="${DIFFYML_VERSION#v}"
+    case "$DIFFYML_VERSION" in
+        ''|*[!0-9.]*|.*|*..*|*.) err "invalid DIFFYML_VERSION: $DIFFYML_VERSION (expected MAJOR.MINOR.PATCH)" ;;
+    esac
 
     archive="diffyml_${DIFFYML_VERSION}_${os}_${arch}.tar.gz"
     base_url="https://github.com/${REPO}/releases/download/v${DIFFYML_VERSION}"
 
     tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' EXIT
+    trap cleanup EXIT INT HUP TERM
 
     info "downloading ${archive}..."
     curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" \
@@ -78,7 +81,7 @@ main() {
                     || err "could not fetch cosign bundle"
                 cosign verify-blob "${tmpdir}/checksums.txt" \
                     --bundle "${tmpdir}/checksums.txt.sigstore.json" \
-                    --certificate-identity-regexp "https://github.com/${REPO}/" \
+                    --certificate-identity-regexp "^https://github\\.com/${REPO}/\\.github/workflows/release\\.yml@refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+\$" \
                     --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
                     >/dev/null \
                     || err "cosign verification failed"
@@ -120,8 +123,12 @@ main() {
         *":${INSTALL_DIR}:"*) ;;
         *) info "note: ${INSTALL_DIR} is not in your PATH" ;;
     esac
+
+    cleanup
+    trap - EXIT INT HUP TERM
 }
 
+cleanup() { [ -n "${tmpdir:-}" ] && rm -rf "$tmpdir"; tmpdir=""; }
 err() { printf 'error: %s\n' "$1" >&2; exit 1; }
 info() { printf '%s\n' "$1"; }
 require() { command -v "$1" >/dev/null 2>&1 || err "$1 not found in PATH"; }

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# diffyml installer
+#
+# Usage:
+#   curl -fsSL https://szhekpisov.github.io/diffyml/install.sh | sh
+#
+# Environment variables:
+#   DIFFYML_VERSION  version to install, e.g. 1.6.0 (default: latest release)
+#   INSTALL_DIR      install directory (default: /usr/local/bin)
+#   VERIFY           verification mode: sha256 (default), cosign, none
+
+set -eu
+
+REPO="szhekpisov/diffyml"
+DIFFYML_VERSION="${DIFFYML_VERSION:-}"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+VERIFY="${VERIFY:-sha256}"
+
+err() { printf 'error: %s\n' "$1" >&2; exit 1; }
+info() { printf '%s\n' "$1"; }
+require() { command -v "$1" >/dev/null 2>&1 || err "$1 not found in PATH"; }
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        err "no sha256sum or shasum found in PATH"
+    fi
+}
+
+require curl
+require tar
+require uname
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$os" in
+    linux|darwin) ;;
+    *) err "unsupported OS: $os (only linux and darwin are supported)" ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+    x86_64|amd64)    arch=amd64 ;;
+    aarch64|arm64)   arch=arm64 ;;
+    *) err "unsupported architecture: $arch (only amd64 and arm64 are supported)" ;;
+esac
+
+if [ -z "$DIFFYML_VERSION" ]; then
+    info "fetching latest version..."
+    DIFFYML_VERSION=$(
+        curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+            | grep '"tag_name"' \
+            | head -1 \
+            | cut -d'"' -f4
+    )
+    [ -n "$DIFFYML_VERSION" ] || err "could not determine latest version"
+fi
+DIFFYML_VERSION="${DIFFYML_VERSION#v}"
+
+archive="diffyml_${DIFFYML_VERSION}_${os}_${arch}.tar.gz"
+base_url="https://github.com/${REPO}/releases/download/v${DIFFYML_VERSION}"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+info "downloading ${archive}..."
+curl -fsSL -o "${tmpdir}/${archive}" "${base_url}/${archive}" \
+    || err "download failed: ${base_url}/${archive}"
+
+case "$VERIFY" in
+    none)
+        info "skipping verification (VERIFY=none)"
+        ;;
+    sha256|cosign)
+        curl -fsSL -o "${tmpdir}/checksums.txt" "${base_url}/checksums.txt" \
+            || err "could not fetch checksums.txt"
+
+        if [ "$VERIFY" = cosign ]; then
+            require cosign
+            info "verifying cosign signature on checksums.txt..."
+            curl -fsSL -o "${tmpdir}/checksums.txt.sigstore.json" \
+                "${base_url}/checksums.txt.sigstore.json" \
+                || err "could not fetch cosign bundle"
+            cosign verify-blob "${tmpdir}/checksums.txt" \
+                --bundle "${tmpdir}/checksums.txt.sigstore.json" \
+                --certificate-identity-regexp "https://github.com/${REPO}/" \
+                --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+                >/dev/null 2>&1 \
+                || err "cosign verification failed"
+            info "cosign signature verified"
+        fi
+
+        info "verifying SHA256..."
+        expected=$(awk -v f="$archive" '$2 == f {print $1}' "${tmpdir}/checksums.txt")
+        [ -n "$expected" ] || err "no SHA256 entry for ${archive} in checksums.txt"
+        actual=$(sha256_of "${tmpdir}/${archive}")
+        [ "$actual" = "$expected" ] \
+            || err "SHA256 mismatch (expected $expected, got $actual)"
+        info "SHA256 verified"
+        ;;
+    *)
+        err "unknown VERIFY mode: $VERIFY (use sha256, cosign, or none)"
+        ;;
+esac
+
+info "extracting..."
+tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
+[ -f "${tmpdir}/diffyml" ] || err "diffyml binary not found in archive"
+chmod +x "${tmpdir}/diffyml"
+
+if mkdir -p "$INSTALL_DIR" 2>/dev/null && [ -w "$INSTALL_DIR" ]; then
+    mv "${tmpdir}/diffyml" "${INSTALL_DIR}/diffyml"
+elif command -v sudo >/dev/null 2>&1; then
+    info "installing to ${INSTALL_DIR} (requires sudo)..."
+    sudo mkdir -p "$INSTALL_DIR"
+    sudo mv "${tmpdir}/diffyml" "${INSTALL_DIR}/diffyml"
+else
+    err "cannot write to ${INSTALL_DIR} and sudo not available; set INSTALL_DIR"
+fi
+
+info ""
+info "diffyml ${DIFFYML_VERSION} installed to ${INSTALL_DIR}/diffyml"
+
+case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *) info "note: ${INSTALL_DIR} is not in your PATH" ;;
+esac

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -5,7 +5,7 @@
 #   curl -fsSL https://szhekpisov.github.io/diffyml/install.sh | sh
 #
 # Environment variables:
-#   DIFFYML_VERSION  version to install, e.g. 1.6.0 (default: latest release)
+#   DIFFYML_VERSION  version to install, e.g. 1.6.1 (default: latest release)
 #   INSTALL_DIR      install directory (default: /usr/local/bin)
 #   VERIFY           verification mode: sha256 (default), cosign, none
 #   GITHUB_TOKEN     optional, used for the GitHub API call when resolving


### PR DESCRIPTION
## What

Add native `.deb`, `.rpm`, and `.apk` packages to every release for `linux/amd64` and `linux/arm64`, extend SBOM/cosign coverage to those packages, ship a POSIX `install.sh` (auto OS/arch detection + SHA256/cosign verification) hosted via the docs site, and document all of the above plus the previously-undocumented direct binary download path.

## Why

`go install` and `brew install` cover developer workstations, but the most common Linux CI/runtime environments expect a native package manager. Adding nfpm-built packages closes that gap with effectively zero maintenance cost since goreleaser already builds the binaries.

The README and docs site also lacked a documented `curl | tar` flow for the existing tarballs, which is the simplest install path for environments without Go or Homebrew.

## How

- **`.goreleaser.yaml`** — added an `nfpms` block producing `.deb`/`.rpm`/`.apk` for linux amd64/arm64. Binary lands at `/usr/bin/diffyml`. License files use format-specific paths via `packager:` filters: `/usr/share/doc/diffyml/copyright` for deb (Debian convention) and `/usr/share/licenses/diffyml/LICENSE` for rpm/apk. `README.md` installs at `/usr/share/doc/diffyml/README.md` for all formats. Reproducible mtime via `{{ .CommitDate }}`. Maintainer uses the GitHub noreply email.
- **SBOMs** — split the `sboms` block into two entries (`archive` + `package`) so syft catalogs both. Existing `signs[1]: artifacts: sbom` automatically picks up the new package SBOMs and signs them with cosign — no signing-side change needed.
- **`docs/static/install.sh`** — POSIX shell installer hosted via Hugo's `static/` directory at `https://szhekpisov.github.io/diffyml/install.sh`. Detects OS/arch, downloads the matching archive, verifies SHA256 against the signed `checksums.txt` by default. Wrapped in `main()` invoked at EOF so a partial `curl | sh` cannot run a truncated script. Honors `DIFFYML_VERSION` (validated as dotted digits), `INSTALL_DIR`, `VERIFY` (`sha256`/`cosign`/`none`), and optionally `GITHUB_TOKEN` for the API call. The cosign cert-identity regex is anchored to the release.yml workflow on a `vSEMVER` tag (`^https://github\.com/REPO/\.github/workflows/release\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$`) so it can't fail-open on a forged SAN containing the repo path. Cleanup uses a global function with a trap on `EXIT/INT/HUP/TERM` cleared on success so it doesn't leak into a sourcing shell.
- **README + docs site** — new sections for install script, Linux packages, and direct binary download. Linux packages section calls out that .deb/.rpm/.apk are covered by the cosign-signed `checksums.txt` and explains the `--allow-untrusted` apk caveat. All `curl` invocations use `-f` so HTTP errors fail fast.

Verified locally with `goreleaser release --snapshot`: all 6 packages built and inspected — deb has copyright at the Debian path, rpm/apk have LICENSE under `/usr/share/licenses/diffyml/`. `install.sh` exercised end-to-end against live `v1.6.0` in both `sha256` and `cosign` modes; the anchored cosign regex matches. `shellcheck` clean. `DIFFYML_VERSION=../../etc/passwd` is rejected before any URL is built.

## Caveats

- **The install.sh URL won't resolve until this PR merges and the docs site redeploys.** It works locally (the script itself is correct) but `curl https://szhekpisov.github.io/diffyml/install.sh` will 404 until merge.
- README/docs hardcode `1.6.0` in package install snippets for clarity — same convention as existing install examples.

## Checklist

- [x] PR title follows convention (`feat:`)
- [ ] `make ci` passes locally — not run; this PR only touches release config, install script, and docs (no Go code changes)
- [x] New/changed behavior covered by tests — N/A (release pipeline; verified via snapshot build and live install.sh runs)
- [x] Coverage thresholds met — N/A (no Go code changes)
- [x] No new dependencies (or justified)

## Notes for reviewers

- CI already installs `syft` via `anchore/sbom-action/download-syft` (`.github/workflows/release.yml:84`), so package SBOMs will generate on the next release without workflow changes.
- The `checksums.txt` automatically includes the new packages (goreleaser default), so the existing cosign-signed checksum file extends provenance coverage to them.
- Debian-style changelog file (`/usr/share/doc/diffyml/changelog.Debian.gz`) is intentionally skipped — adding it would require maintaining a yaml changelog or wiring git-cliff to emit one. Lintian will warn but it's not breaking.