### PR TITLE
test: kill surviving mutants in pkg/diffyml/kubernetes.go

### DIFF
--- a/pkg/diffyml/kubernetes.go
+++ b/pkg/diffyml/kubernetes.go
@@ -33,34 +33,22 @@ func IsKubernetesResource(doc any) bool {
 		}
 	}
 
-	// Check for apiVersion
-	apiVersion, ok := getVal(doc, "apiVersion")
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent: the subsequent !isStr check returns false for the nil zero-value too"
-	if !ok {
+	// apiVersion and kind must be present as string values. A single type-
+	// assertion check covers both "missing key" (getVal returns nil) and
+	// "wrong type" — the redundant existence check was dead defensive code.
+	apiVersion, _ := getVal(doc, "apiVersion")
+	if _, ok := apiVersion.(string); !ok {
 		return false
 	}
-	if _, isStr := apiVersion.(string); !isStr {
-		return false
-	}
-
-	// Check for kind
-	kind, ok := getVal(doc, "kind")
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent: the subsequent !isStr check returns false for the nil zero-value too"
-	if !ok {
-		return false
-	}
-	if _, isStr := kind.(string); !isStr {
+	kind, _ := getVal(doc, "kind")
+	if _, ok := kind.(string); !ok {
 		return false
 	}
 
-	// Check for metadata
-	metadata, ok := getVal(doc, "metadata")
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent: getVal on nil metadata returns (nil,false) for name and generateName, so the next guard returns false"
-	if !ok {
-		return false
-	}
-
-	// Check for name or generateName in metadata
+	// metadata may be any value — getVal(nil/non-map, …) returns (nil, false)
+	// for name and generateName, so the guard below also catches missing
+	// metadata.
+	metadata, _ := getVal(doc, "metadata")
 	metaName, hasName := getVal(metadata, "name")
 	metaGenName, hasGenName := getVal(metadata, "generateName")
 	if (!hasName || metaName == nil) && (!hasGenName || metaGenName == nil) {
@@ -147,13 +135,10 @@ func K8sResourceDisplayName(doc any) string {
 }
 
 // K8sResourceKind returns the "kind" field of a Kubernetes resource document.
-// Returns empty string if the document is not a valid K8s resource.
+// Returns empty string if the document is not a valid K8s resource (the
+// zero-value k8sResourceFields has an empty kind, so no explicit guard).
 func K8sResourceKind(doc any) string {
-	f, ok := k8sExtractFields(doc)
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent: f.kind on the zero-value k8sResourceFields is also \"\""
-	if !ok {
-		return ""
-	}
+	f, _ := k8sExtractFields(doc)
 	return f.kind
 }
 
@@ -189,11 +174,6 @@ func IdentifierWithAdditional(m map[string]any, additionalIdentifiers []string) 
 // CanMatchByIdentifierWithAdditional checks if list items can be matched by identifier,
 // including additional identifier fields.
 func CanMatchByIdentifierWithAdditional(list []any, additionalIdentifiers []string) bool {
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent: an empty range loop leaves hasIdentifier=false, yielding the same false return"
-	if len(list) == 0 {
-		return false
-	}
-
 	hasIdentifier := false
 	for _, item := range list {
 		// Check for OrderedMap
@@ -290,11 +270,9 @@ func matchK8sDocuments(from, to []any, opts *Options) (matched map[int]int, unma
 
 // detectK8sOrderChanges detects document order changes among matched K8s documents.
 func detectK8sOrderChanges(matched map[int]int, from []any, ignoreApiVersion bool) *Difference {
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent: IsSortedFunc on a 0- or 1-element pairs slice is trivially true, so orderChanged stays false and the function returns nil"
-	if len(matched) < 2 {
-		return nil
-	}
-
+	// No early-return for len(matched) < 2: the loop builds an empty/singleton
+	// pairs slice, IsSortedFunc is trivially true, orderChanged stays false,
+	// and the function returns nil naturally.
 	type idxPair struct{ fromIdx, toIdx int }
 	pairs := make([]idxPair, 0, len(matched))
 	for fromIdx, toIdx := range matched {

--- a/pkg/diffyml/kubernetes.go
+++ b/pkg/diffyml/kubernetes.go
@@ -35,6 +35,7 @@ func IsKubernetesResource(doc any) bool {
 
 	// Check for apiVersion
 	apiVersion, ok := getVal(doc, "apiVersion")
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent: the subsequent !isStr check returns false for the nil zero-value too"
 	if !ok {
 		return false
 	}
@@ -44,6 +45,7 @@ func IsKubernetesResource(doc any) bool {
 
 	// Check for kind
 	kind, ok := getVal(doc, "kind")
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent: the subsequent !isStr check returns false for the nil zero-value too"
 	if !ok {
 		return false
 	}
@@ -53,6 +55,7 @@ func IsKubernetesResource(doc any) bool {
 
 	// Check for metadata
 	metadata, ok := getVal(doc, "metadata")
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent: getVal on nil metadata returns (nil,false) for name and generateName, so the next guard returns false"
 	if !ok {
 		return false
 	}
@@ -147,6 +150,7 @@ func K8sResourceDisplayName(doc any) string {
 // Returns empty string if the document is not a valid K8s resource.
 func K8sResourceKind(doc any) string {
 	f, ok := k8sExtractFields(doc)
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent: f.kind on the zero-value k8sResourceFields is also \"\""
 	if !ok {
 		return ""
 	}
@@ -185,6 +189,7 @@ func IdentifierWithAdditional(m map[string]any, additionalIdentifiers []string) 
 // CanMatchByIdentifierWithAdditional checks if list items can be matched by identifier,
 // including additional identifier fields.
 func CanMatchByIdentifierWithAdditional(list []any, additionalIdentifiers []string) bool {
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent: an empty range loop leaves hasIdentifier=false, yielding the same false return"
 	if len(list) == 0 {
 		return false
 	}
@@ -285,6 +290,7 @@ func matchK8sDocuments(from, to []any, opts *Options) (matched map[int]int, unma
 
 // detectK8sOrderChanges detects document order changes among matched K8s documents.
 func detectK8sOrderChanges(matched map[int]int, from []any, ignoreApiVersion bool) *Difference {
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent: IsSortedFunc on a 0- or 1-element pairs slice is trivially true, so orderChanged stays false and the function returns nil"
 	if len(matched) < 2 {
 		return nil
 	}
@@ -360,7 +366,9 @@ func compareK8sDocs(from, to []any, opts *Options) []Difference {
 	var diffs []Difference
 
 	matched, unmatchedFrom, unmatchedTo := matchK8sDocuments(from, to, opts)
-	ignoreApiVersion := opts != nil && opts.IgnoreApiVersion
+	// opts is guaranteed non-nil by the caller (compareDocs gates on opts != nil),
+	// and we dereference opts.IgnoreOrderChanges immediately below.
+	ignoreApiVersion := opts.IgnoreApiVersion
 
 	// Detect document order changes
 	if !opts.IgnoreOrderChanges {

--- a/pkg/diffyml/kubernetes_test.go
+++ b/pkg/diffyml/kubernetes_test.go
@@ -1,6 +1,7 @@
 package diffyml
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -1481,5 +1482,469 @@ func TestK8sResourceDisplayName_WithoutNamespace(t *testing.T) {
 	want := "v1/Namespace/prod"
 	if got := K8sResourceDisplayName(doc); got != want {
 		t.Errorf("K8sResourceDisplayName() = %q, want %q", got, want)
+	}
+}
+
+// TestIsKubernetesResource_NameExplicitNil covers the path where metadata.name
+// exists as a key but holds an explicit nil — without the generateName fallback
+// the resource must be rejected. Kills the INVERT_LOGICAL mutant on the first
+// `||` in the (!hasName || metaName == nil) && (!hasGenName || metaGenName == nil)
+// guard: if `||` becomes `&&`, the left clause flips to false (hasName=true,
+// metaName=nil → false && true = false), the whole && is false, and the
+// document is wrongly accepted as a K8s resource.
+func TestIsKubernetesResource_NameExplicitNil(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": nil},
+	}
+	if IsKubernetesResource(doc) {
+		t.Error("expected explicit nil name to NOT be detected as K8s resource")
+	}
+}
+
+// TestIsKubernetesResource_GenerateNameExplicitNil mirrors the above for the
+// second `||` clause: when generateName is present but nil and there is no
+// name, the resource must be rejected.
+func TestIsKubernetesResource_GenerateNameExplicitNil(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"generateName": nil},
+	}
+	if IsKubernetesResource(doc) {
+		t.Error("expected explicit nil generateName to NOT be detected as K8s resource")
+	}
+}
+
+// TestCanMatchByIdentifierWithAdditional_OrderedMapWithoutIdContinuesLoop
+// places an OrderedMap with no identifier before a plain map that does have
+// one. The function must `continue` past the OM and inspect the map. Kills the
+// INVERT_LOOP_CTRL mutant that flips `continue` to `break` — with `break`, the
+// map is never inspected and hasIdentifier stays false.
+func TestCanMatchByIdentifierWithAdditional_OrderedMapWithoutIdContinuesLoop(t *testing.T) {
+	omWithoutId := NewOrderedMap()
+	omWithoutId.Keys = append(omWithoutId.Keys, "foo")
+	omWithoutId.Values["foo"] = "bar"
+
+	list := []any{
+		omWithoutId,
+		map[string]any{"name": "real"},
+	}
+	if !CanMatchByIdentifierWithAdditional(list, nil) {
+		t.Error("expected later plain map with name to make the list matchable")
+	}
+}
+
+// TestCanMatchByIdentifierWithAdditional_NonMapItemRejected ensures a non-map
+// element short-circuits to false even when a later element would otherwise
+// supply an identifier. Kills the BRANCH_IF mutant that removes the early
+// `return false` for non-map items — with the mutation, the non-map is
+// silently skipped and the trailing map's identifier wrongly makes the list
+// matchable.
+func TestCanMatchByIdentifierWithAdditional_NonMapItemRejected(t *testing.T) {
+	list := []any{
+		"not-a-map",
+		map[string]any{"name": "real"},
+	}
+	if CanMatchByIdentifierWithAdditional(list, nil) {
+		t.Error("expected list containing a non-map item to NOT be matchable")
+	}
+}
+
+// TestMatchK8sDocuments_NilOptsDoesNotPanic exercises the defensive `opts !=
+// nil` guard. Kills the EXPRESSION_REMOVE mutant that replaces `opts != nil`
+// with `true` — the mutated code then dereferences opts.IgnoreApiVersion and
+// panics.
+func TestMatchK8sDocuments_NilOptsDoesNotPanic(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "x"},
+	}
+	matched, unmatchedFrom, unmatchedTo := matchK8sDocuments([]any{doc}, []any{doc}, nil)
+	if len(matched) != 1 || matched[0] != 0 {
+		t.Errorf("expected from[0] matched to to[0] with nil opts, got matched=%v", matched)
+	}
+	if len(unmatchedFrom) != 0 {
+		t.Errorf("expected 0 unmatched from, got %d", len(unmatchedFrom))
+	}
+	if len(unmatchedTo) != 0 {
+		t.Errorf("expected 0 unmatched to, got %d", len(unmatchedTo))
+	}
+}
+
+// TestDetectK8sOrderChanges_PositionalMatchingStaysNil runs detection many
+// times against a positional match (no real reorder) to overcome Go's
+// randomized map iteration. Kills the STATEMENT_REMOVE mutant on the
+// first slices.SortFunc — without sorting pairs by fromIdx, the subsequent
+// IsSortedFunc check inspects randomly-ordered pairs and almost always
+// reports a false order change.
+func TestDetectK8sOrderChanges_PositionalMatchingStaysNil(t *testing.T) {
+	mkDoc := func(name string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": name},
+		}
+	}
+	from := []any{mkDoc("a"), mkDoc("b"), mkDoc("c"), mkDoc("d")}
+	matched := map[int]int{0: 0, 1: 1, 2: 2, 3: 3}
+	for i := range 200 {
+		if diff := detectK8sOrderChanges(matched, from, false); diff != nil {
+			t.Fatalf("iteration %d: positional matching must not report order change, got %+v", i, diff)
+		}
+	}
+}
+
+// TestDetectK8sOrderChanges_ToOrderInToSideOrder asserts that the toOrder
+// field of the produced Difference reflects the to-side ordering (i.e.,
+// pairs sorted by toIdx), distinct from fromOrder. Kills the
+// STATEMENT_REMOVE mutant on the second slices.SortFunc — without that
+// re-sort, toOrder is rendered in fromIdx order and ends up identical to
+// fromOrder.
+func TestDetectK8sOrderChanges_ToOrderInToSideOrder(t *testing.T) {
+	mkDoc := func(name string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": name},
+		}
+	}
+	// from = [a, b]; to = [b, a]  => matched = {0:1, 1:0}
+	from := []any{mkDoc("a"), mkDoc("b")}
+	matched := map[int]int{0: 1, 1: 0}
+
+	diff := detectK8sOrderChanges(matched, from, false)
+	if diff == nil {
+		t.Fatal("expected order change for swapped pair")
+	}
+	wantFrom := []any{"v1:ConfigMap:a", "v1:ConfigMap:b"}
+	wantTo := []any{"v1:ConfigMap:b", "v1:ConfigMap:a"}
+	if !reflect.DeepEqual(diff.From, wantFrom) {
+		t.Errorf("fromOrder = %v, want %v", diff.From, wantFrom)
+	}
+	if !reflect.DeepEqual(diff.To, wantTo) {
+		t.Errorf("toOrder = %v, want %v", diff.To, wantTo)
+	}
+}
+
+// TestCompareMatchedK8sDocs_UseToIdxAffectsPath constructs a matched pair
+// where fromIdx (0) differs from toIdx (1) and calls compareMatchedK8sDocs
+// with useToIdx=true. The resulting diff's path prefix and DocumentIndex
+// must reflect toIdx=1. Kills the BRANCH_IF mutant on `if useToIdx` and the
+// STATEMENT_REMOVE mutant on `docIdx = toIdx`.
+func TestCompareMatchedK8sDocs_UseToIdxAffectsPath(t *testing.T) {
+	mkDoc := func(name, val string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": name},
+			"data":       map[string]any{"k": val},
+		}
+	}
+	from := []any{mkDoc("cfg", "old"), mkDoc("other", "x")}
+	to := []any{mkDoc("other", "x"), mkDoc("cfg", "new")}
+	matched := map[int]int{0: 1}
+
+	diffs := compareMatchedK8sDocs(matched, from, to, &Options{DetectKubernetes: true}, true)
+
+	var mod *Difference
+	for i := range diffs {
+		if diffs[i].Type == DiffModified && diffs[i].From == "old" && diffs[i].To == "new" {
+			mod = &diffs[i]
+			break
+		}
+	}
+	if mod == nil {
+		t.Fatal("expected data.k modification diff")
+	}
+	if !strings.HasPrefix(mod.Path.String(), "[1]") {
+		t.Errorf("path = %q, want [1] prefix (toIdx)", mod.Path.String())
+	}
+	if mod.DocumentIndex != 1 {
+		t.Errorf("DocumentIndex = %d, want 1 (toIdx)", mod.DocumentIndex)
+	}
+}
+
+// TestCompareMatchedK8sDocs_PathPrefix_FromHasMore covers the asymmetric
+// case where the from side has multiple documents but the to side does
+// not. The pathPrefix must still be set (per the original
+// `len(from) > 1 || len(to) > 1` guard). Kills the EXPRESSION_REMOVE
+// mutant on `len(from) > 1` (→ false) and the INVERT_LOGICAL mutant on
+// the `||` (→ &&), both of which would drop the prefix in this shape.
+func TestCompareMatchedK8sDocs_PathPrefix_FromHasMore(t *testing.T) {
+	mkDoc := func(name, val string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": name},
+			"data":       map[string]any{"k": val},
+		}
+	}
+	from := []any{mkDoc("cfg", "old"), mkDoc("extra", "x")}
+	to := []any{mkDoc("cfg", "new")}
+	matched := map[int]int{0: 0}
+
+	diffs := compareMatchedK8sDocs(matched, from, to, &Options{DetectKubernetes: true}, false)
+
+	var mod *Difference
+	for i := range diffs {
+		if diffs[i].Type == DiffModified && diffs[i].From == "old" && diffs[i].To == "new" {
+			mod = &diffs[i]
+			break
+		}
+	}
+	if mod == nil {
+		t.Fatal("expected data.k modification diff")
+	}
+	if !strings.HasPrefix(mod.Path.String(), "[0]") {
+		t.Errorf("path = %q, want [0] prefix when from has multiple docs", mod.Path.String())
+	}
+}
+
+// TestCompareMatchedK8sDocs_PathPrefix_ToHasMore mirrors the above for the
+// to side having multiple documents. Kills the EXPRESSION_REMOVE mutant on
+// `len(to) > 1` (→ false) and reinforces the INVERT_LOGICAL kill on the
+// `||`.
+func TestCompareMatchedK8sDocs_PathPrefix_ToHasMore(t *testing.T) {
+	mkDoc := func(name, val string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": name},
+			"data":       map[string]any{"k": val},
+		}
+	}
+	from := []any{mkDoc("cfg", "old")}
+	to := []any{mkDoc("cfg", "new"), mkDoc("extra", "x")}
+	matched := map[int]int{0: 0}
+
+	diffs := compareMatchedK8sDocs(matched, from, to, &Options{DetectKubernetes: true}, false)
+
+	var mod *Difference
+	for i := range diffs {
+		if diffs[i].Type == DiffModified && diffs[i].From == "old" && diffs[i].To == "new" {
+			mod = &diffs[i]
+			break
+		}
+	}
+	if mod == nil {
+		t.Fatal("expected data.k modification diff")
+	}
+	if !strings.HasPrefix(mod.Path.String(), "[0]") {
+		t.Errorf("path = %q, want [0] prefix when to has multiple docs", mod.Path.String())
+	}
+}
+
+// TestCompareMatchedK8sDocs_SetsDocFields asserts that the document
+// metadata is populated on every diff returned from compareMatchedK8sDocs.
+// Kills the STATEMENT_REMOVE mutants on lines that:
+//   - extract docName/docKind from the to-side document (lines 345, 346),
+//   - assign DocumentIndex/Name/Kind onto each nodeDiff (lines 349-351).
+func TestCompareMatchedK8sDocs_SetsDocFields(t *testing.T) {
+	mkCfg := func(val string) map[string]any {
+		return map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "cfg"},
+			"data":       map[string]any{"k": val},
+		}
+	}
+	mkOther := func() map[string]any {
+		return map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata":   map[string]any{"name": "svc"},
+			"spec":       map[string]any{"port": 80},
+		}
+	}
+	from := []any{mkOther(), mkCfg("old")}
+	to := []any{mkOther(), mkCfg("new")}
+	matched := map[int]int{1: 1}
+
+	diffs := compareMatchedK8sDocs(matched, from, to, &Options{DetectKubernetes: true}, false)
+
+	var mod *Difference
+	for i := range diffs {
+		if diffs[i].Type == DiffModified && diffs[i].From == "old" && diffs[i].To == "new" {
+			mod = &diffs[i]
+			break
+		}
+	}
+	if mod == nil {
+		t.Fatal("expected data.k modification diff")
+	}
+	if mod.DocumentIndex != 1 {
+		t.Errorf("DocumentIndex = %d, want 1", mod.DocumentIndex)
+	}
+	if mod.DocumentName != "v1/ConfigMap/cfg" {
+		t.Errorf("DocumentName = %q, want %q", mod.DocumentName, "v1/ConfigMap/cfg")
+	}
+	if mod.DocumentKind != "ConfigMap" {
+		t.Errorf("DocumentKind = %q, want %q", mod.DocumentKind, "ConfigMap")
+	}
+}
+
+// TestCompareK8sDocs_OrderChange_FullIdentifiersWhenNotIgnoringApiVersion
+// is the dual of TestCompareK8sDocs_IgnoreApiVersion_OrderChangeIdentifiers:
+// with IgnoreApiVersion=false the order-change diff's identifiers must
+// include the apiVersion. Kills the EXPRESSION_REMOVE mutant on
+// `opts.IgnoreApiVersion` (→ true) inside compareK8sDocs, which would
+// strip the apiVersion from the rendered identifiers.
+func TestCompareK8sDocs_OrderChange_FullIdentifiersWhenNotIgnoringApiVersion(t *testing.T) {
+	mkDoc := func(name string) map[string]any {
+		return map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]any{"name": name, "namespace": "default"},
+			"spec":       map[string]any{"replicas": 1},
+		}
+	}
+	from := []any{mkDoc("a"), mkDoc("b")}
+	to := []any{mkDoc("b"), mkDoc("a")}
+
+	diffs := compareK8sDocs(from, to, &Options{DetectKubernetes: true})
+
+	var orderDiff *Difference
+	for i := range diffs {
+		if diffs[i].Type == DiffOrderChanged {
+			orderDiff = &diffs[i]
+			break
+		}
+	}
+	if orderDiff == nil {
+		t.Fatal("expected DiffOrderChanged for reordered docs")
+	}
+	fromOrder, ok := orderDiff.From.([]any)
+	if !ok {
+		t.Fatalf("expected From to be []any, got %T", orderDiff.From)
+	}
+	for _, id := range fromOrder {
+		idStr, _ := id.(string)
+		if !strings.Contains(idStr, "apps/v1") {
+			t.Errorf("with IgnoreApiVersion=false, identifier must include apiVersion, got %q", idStr)
+		}
+	}
+}
+
+// TestCompareK8sDocs_RemovedSkipsNilThenReportsReal places a nil entry
+// before a real K8s document in the unmatched-from set. The real document
+// must still be reported as removed. Kills the INVERT_LOOP_CTRL mutant
+// that flips `continue` to `break` on the nil-skip — with `break`, the
+// loop exits after the nil and the real removal is never emitted.
+func TestCompareK8sDocs_RemovedSkipsNilThenReportsReal(t *testing.T) {
+	realDoc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "to-remove"},
+		"data":       map[string]any{"k": "v"},
+	}
+	from := []any{nil, realDoc}
+	to := []any{}
+
+	diffs := compareK8sDocs(from, to, &Options{DetectKubernetes: true})
+
+	found := false
+	for _, d := range diffs {
+		if d.Type == DiffRemoved && d.DocumentIndex == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected the real K8s doc at index 1 to be reported as removed even when index 0 is nil")
+	}
+}
+
+// TestCompareK8sDocs_AddedSkipsNilThenReportsReal is the to-side analog
+// of the test above. Kills the INVERT_LOOP_CTRL mutant on the added-docs
+// loop.
+func TestCompareK8sDocs_AddedSkipsNilThenReportsReal(t *testing.T) {
+	realDoc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "to-add"},
+		"data":       map[string]any{"k": "v"},
+	}
+	from := []any{}
+	to := []any{nil, realDoc}
+
+	diffs := compareK8sDocs(from, to, &Options{DetectKubernetes: true})
+
+	found := false
+	for _, d := range diffs {
+		if d.Type == DiffAdded && d.DocumentIndex == 1 {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected the real K8s doc at index 1 to be reported as added even when index 0 is nil")
+	}
+}
+
+// TestCompareK8sDocs_RemovedCarriesDocFields asserts that the removed-doc
+// branch populates DocumentName/DocumentKind from the from-side resource.
+// Kills the STATEMENT_REMOVE mutants on `docName = f.displayName()` and
+// `docKind = f.kind` in the removed branch.
+func TestCompareK8sDocs_RemovedCarriesDocFields(t *testing.T) {
+	removed := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]any{"name": "creds", "namespace": "prod"},
+		"data":       map[string]any{"k": "v"},
+	}
+	from := []any{removed}
+	to := []any{}
+
+	diffs := compareK8sDocs(from, to, &Options{DetectKubernetes: true})
+
+	var rem *Difference
+	for i := range diffs {
+		if diffs[i].Type == DiffRemoved {
+			rem = &diffs[i]
+			break
+		}
+	}
+	if rem == nil {
+		t.Fatal("expected removed diff")
+	}
+	if rem.DocumentName != "v1/Secret/prod/creds" {
+		t.Errorf("DocumentName = %q, want %q", rem.DocumentName, "v1/Secret/prod/creds")
+	}
+	if rem.DocumentKind != "Secret" {
+		t.Errorf("DocumentKind = %q, want %q", rem.DocumentKind, "Secret")
+	}
+}
+
+// TestCompareK8sDocs_AddedCarriesDocFields is the to-side analog. Kills
+// the STATEMENT_REMOVE mutants on `docName = f.displayName()` and
+// `docKind = f.kind` in the added branch.
+func TestCompareK8sDocs_AddedCarriesDocFields(t *testing.T) {
+	added := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata":   map[string]any{"name": "creds", "namespace": "prod"},
+		"data":       map[string]any{"k": "v"},
+	}
+	from := []any{}
+	to := []any{added}
+
+	diffs := compareK8sDocs(from, to, &Options{DetectKubernetes: true})
+
+	var add *Difference
+	for i := range diffs {
+		if diffs[i].Type == DiffAdded {
+			add = &diffs[i]
+			break
+		}
+	}
+	if add == nil {
+		t.Fatal("expected added diff")
+	}
+	if add.DocumentName != "v1/Secret/prod/creds" {
+		t.Errorf("DocumentName = %q, want %q", add.DocumentName, "v1/Secret/prod/creds")
+	}
+	if add.DocumentKind != "Secret" {
+		t.Errorf("DocumentKind = %q, want %q", add.DocumentKind, "Secret")
 	}
 }


### PR DESCRIPTION
## What

Close the mutation-testing gap in `pkg/diffyml/kubernetes.go`: 32 surviving mutants → 0. Per-file efficacy goes from 67.35% to **100%** (85 KILLED, 0 SUPPRESSED, 0 LIVED).

## Why

`kubernetes.go` was the weakest file in the package by mutant efficacy. Order-change rendering, document-metadata propagation, and the rename-detection `useToIdx` branch were all untested at the mutation level — silent regressions in any of them would not have been caught by the existing tests.

## How

### 1. New tests (commit 1)

**16 new tests** target the surviving mutants:

- `IsKubernetesResource` — explicit `metadata.name: null` and `metadata.generateName: null` cases (kills the two `INVERT_LOGICAL` mutants on the `||` operators).
- `CanMatchByIdentifierWithAdditional` — OrderedMap-without-id followed by a plain-map-with-id (kills `INVERT_LOOP_CTRL` on the `continue`); non-map item followed by a map (kills the early `return false`).
- `matchK8sDocuments` — call with `nil` opts (kills the `opts != nil` `EXPRESSION_REMOVE`, which would panic when mutated).
- `detectK8sOrderChanges` — 200-iteration positional-matching loop (statistically kills the first `SortFunc` removal despite Go's randomized map iteration); 2-doc swap asserting `toOrder` reflects to-side ordering (kills the second `SortFunc` removal).
- `compareMatchedK8sDocs` — `useToIdx=true` with `fromIdx ≠ toIdx`, asymmetric `len(from)/len(to)` cases for the path-prefix guard, and explicit assertions on `DocumentIndex`/`DocumentName`/`DocumentKind` (kills `BRANCH_IF`, `STATEMENT_REMOVE`, `INVERT_LOGICAL`, and `EXPRESSION_REMOVE` mutants in this function).
- `compareK8sDocs` — full-identifier rendering when `IgnoreApiVersion=false` (kills the `opts.IgnoreApiVersion` `EXPRESSION_REMOVE`); nil-then-real entries in unmatched-from and unmatched-to (kills the `continue → break` `INVERT_LOOP_CTRL`s); `DocumentName`/`Kind` assertions on added/removed diffs.

**One code simplification**: `compareK8sDocs` had `opts != nil && opts.IgnoreApiVersion`, but the very next line dereferences `opts.IgnoreOrderChanges` without a nil guard — the nil check was dead defensive code. Dropping it eliminates both the `opts != nil → true` and `&& → ||` mutants on that line in one step.

### 2. Refactor (commit 2)

The first commit also added six `gomutants:disable-next-line` directives for BRANCH_IF mutants where the early return was shadowed by a downstream check producing the identical result. The follow-up commit removes the redundant guards entirely so the downstream checks become solely responsible — any mutation against them is now observable and killable.

- `IsKubernetesResource`: collapse (key-exists + is-string) into a single type assertion for apiVersion and kind; drop the metadata existence check since `getVal(nil/non-map, …)` already returns `(nil, false)`.
- `K8sResourceKind`: return `f.kind` directly — the zero-value `k8sResourceFields` already carries an empty kind.
- `CanMatchByIdentifierWithAdditional`: drop the `len(list) == 0` early return; an empty range loop leaves `hasIdentifier=false`.
- `detectK8sOrderChanges`: drop the `len(matched) < 2` early return; `IsSortedFunc` is trivially true on 0- or 1-element slices.

Net result: 85 KILLED, 0 SUPPRESSED, 0 LIVED — no directives needed.

## Checklist

- [x] PR title follows convention
- [x] `go test ./pkg/diffyml/` passes
- [x] New behavior covered by tests
- [x] kubernetes.go coverage threshold (95%) still met
- [x] No new dependencies

## Notes for reviewers

The `detectK8sOrderChanges` positional-matching test loops 200×. With the first sort removed, the chance of all 200 iterations happening to produce a toIdx-sorted permutation is `(1/24)^200` — effectively zero — so it kills the mutant deterministically in practice even though map iteration is randomized.