### PR TITLE
test: kill surviving mutants in pkg/diffyml/chroot.go

### DIFF
--- a/pkg/diffyml/chroot.go
+++ b/pkg/diffyml/chroot.go
@@ -26,12 +26,6 @@ func (e *ChrootError) Error() string {
 // Path format: "level1.level2.key" or "items[0].name" for list access.
 // Returns the value at the path, or an error if path doesn't exist.
 func navigateToPath(doc any, path string) (any, error) {
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent; fallthrough path produces identical result — parsePath(\"\") returns nil segments, the loop is skipped, and current=doc is returned"
-	if path == "" {
-		return doc, nil
-	}
-
-	// Parse and navigate path segments
 	segments, err := parsePath(path)
 	if err != nil {
 		return nil, &ChrootError{
@@ -99,12 +93,6 @@ type pathSegment struct {
 // Examples: "foo.bar", "items[0]", "data[0].name"
 func parsePath(path string) ([]pathSegment, error) {
 	var segments []pathSegment
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent; fallthrough produces identical result — splitPath(\"\") returns nil parts, the loop is skipped, and the same nil segments slice is returned"
-	if path == "" {
-		return segments, nil
-	}
-
-	// Split by dots, but handle bracket notation
 	parts, err := splitPath(path)
 	if err != nil {
 		return nil, err
@@ -113,20 +101,14 @@ func parsePath(path string) ([]pathSegment, error) {
 	for _, part := range parts {
 		// Check for bracket notation: key[index]
 		if idx := strings.Index(part, "["); idx >= 0 {
-			// gomutants:disable-next-line BRANCH_IF reason="unreachable; splitPath rejects parts with a second '[' (line: nested bracket), so count[ is always 1 here"
-			if strings.Count(part, "[") != 1 {
-				return nil, fmt.Errorf("invalid list index syntax %q", part)
-			}
-			// gomutants:disable-next-line BRANCH_IF reason="unreachable; splitPath rejects ']' outside brackets and unterminated '[', so count] is always 1 here when count[ is 1"
-			if strings.Count(part, "]") != 1 {
-				return nil, fmt.Errorf("invalid list index syntax %q", part)
-			}
-			if !strings.HasSuffix(part, "]") {
-				return nil, fmt.Errorf("invalid list index syntax %q", part)
-			}
-			// Has index accessor
 			key := part[:idx]
-			indexStr := part[idx+1 : len(part)-1] // Remove [ and ]
+			indexStr := part[idx+1 : len(part)-1]
+			// indexStr must be the only bracketed segment; reject extra
+			// brackets either inside (e.g. "key[0][1]") or trailing past ']'
+			// (e.g. "key[1]extra", where the trailing chars push ']' into indexStr).
+			if strings.ContainsAny(indexStr, "[]") {
+				return nil, fmt.Errorf("invalid list index syntax %q", part)
+			}
 			if indexStr == "" {
 				return nil, fmt.Errorf("empty list index in %q", part)
 			}
@@ -217,11 +199,6 @@ func applyChroot(doc any, path string, listToDocuments bool) ([]any, error) {
 
 // applyChrootToDocs applies chroot to multiple documents.
 func applyChrootToDocs(docs []any, path string, listToDocuments bool) ([]any, error) {
-	// gomutants:disable-next-line BRANCH_IF reason="equivalent; fallthrough calls applyChroot(doc, \"\", _) per doc, which itself early-returns []any{doc}, so result equals docs"
-	if path == "" {
-		return docs, nil
-	}
-
 	var result []any
 	for _, doc := range docs {
 		chrootDocs, err := applyChroot(doc, path, listToDocuments)

--- a/pkg/diffyml/chroot.go
+++ b/pkg/diffyml/chroot.go
@@ -26,6 +26,7 @@ func (e *ChrootError) Error() string {
 // Path format: "level1.level2.key" or "items[0].name" for list access.
 // Returns the value at the path, or an error if path doesn't exist.
 func navigateToPath(doc any, path string) (any, error) {
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent; fallthrough path produces identical result — parsePath(\"\") returns nil segments, the loop is skipped, and current=doc is returned"
 	if path == "" {
 		return doc, nil
 	}
@@ -98,6 +99,7 @@ type pathSegment struct {
 // Examples: "foo.bar", "items[0]", "data[0].name"
 func parsePath(path string) ([]pathSegment, error) {
 	var segments []pathSegment
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent; fallthrough produces identical result — splitPath(\"\") returns nil parts, the loop is skipped, and the same nil segments slice is returned"
 	if path == "" {
 		return segments, nil
 	}
@@ -111,7 +113,15 @@ func parsePath(path string) ([]pathSegment, error) {
 	for _, part := range parts {
 		// Check for bracket notation: key[index]
 		if idx := strings.Index(part, "["); idx >= 0 {
-			if strings.Count(part, "[") != 1 || strings.Count(part, "]") != 1 || !strings.HasSuffix(part, "]") {
+			// gomutants:disable-next-line BRANCH_IF reason="unreachable; splitPath rejects parts with a second '[' (line: nested bracket), so count[ is always 1 here"
+			if strings.Count(part, "[") != 1 {
+				return nil, fmt.Errorf("invalid list index syntax %q", part)
+			}
+			// gomutants:disable-next-line BRANCH_IF reason="unreachable; splitPath rejects ']' outside brackets and unterminated '[', so count] is always 1 here when count[ is 1"
+			if strings.Count(part, "]") != 1 {
+				return nil, fmt.Errorf("invalid list index syntax %q", part)
+			}
+			if !strings.HasSuffix(part, "]") {
 				return nil, fmt.Errorf("invalid list index syntax %q", part)
 			}
 			// Has index accessor
@@ -207,6 +217,7 @@ func applyChroot(doc any, path string, listToDocuments bool) ([]any, error) {
 
 // applyChrootToDocs applies chroot to multiple documents.
 func applyChrootToDocs(docs []any, path string, listToDocuments bool) ([]any, error) {
+	// gomutants:disable-next-line BRANCH_IF reason="equivalent; fallthrough calls applyChroot(doc, \"\", _) per doc, which itself early-returns []any{doc}, so result equals docs"
 	if path == "" {
 		return docs, nil
 	}

--- a/pkg/diffyml/chroot_test.go
+++ b/pkg/diffyml/chroot_test.go
@@ -1,6 +1,7 @@
 package diffyml
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -351,6 +352,78 @@ func TestSplitPath_SimpleKey(t *testing.T) {
 	}
 	if len(parts) > 0 && parts[0] != "key" {
 		t.Errorf("splitPath(\"key\")[0] = %q, want \"key\"", parts[0])
+	}
+}
+
+func TestNavigateToPath_IndexOnNonList_ErrorMessage(t *testing.T) {
+	doc := map[string]any{
+		"data": map[string]any{"key": "value"},
+	}
+	_, err := navigateToPath(doc, "data[0]")
+	if err == nil {
+		t.Fatal("expected error for index access into non-list")
+	}
+	if !strings.Contains(err.Error(), "expected list") {
+		t.Errorf("expected error mentioning \"expected list\", got: %v", err)
+	}
+}
+
+func TestNavigateToPath_NegativeIndex(t *testing.T) {
+	doc := map[string]any{
+		"items": []any{"a", "b", "c"},
+	}
+	_, err := navigateToPath(doc, "items[-1]")
+	if err == nil {
+		t.Fatal("expected error for negative list index, got nil")
+	}
+}
+
+func TestNavigateToPath_KeyThroughScalar_ErrorMessage(t *testing.T) {
+	doc := map[string]any{
+		"scalar": 42,
+	}
+	_, err := navigateToPath(doc, "scalar.field")
+	if err == nil {
+		t.Fatal("expected error for key access through scalar")
+	}
+	if !strings.Contains(err.Error(), "expected map") {
+		t.Errorf("expected error mentioning \"expected map\", got: %v", err)
+	}
+}
+
+func TestParsePath_ExtraAfterBracket(t *testing.T) {
+	if _, err := parsePath("key[1]extra"); err == nil {
+		t.Fatal("expected error for \"key[1]extra\", got nil")
+	}
+}
+
+func TestSplitPath_NestedOpenBracket(t *testing.T) {
+	if _, err := splitPath("a[[]"); err == nil {
+		t.Fatal("expected error for nested '[' in path, got nil")
+	}
+}
+
+func TestSplitPath_UnterminatedBracket(t *testing.T) {
+	if _, err := splitPath("a[1"); err == nil {
+		t.Fatal("expected error for unterminated '[', got nil")
+	}
+}
+
+func TestApplyChroot_EmptyPath_ListDoc_WrapsNotFlattens(t *testing.T) {
+	listDoc := []any{"a", "b", "c"}
+	result, err := applyChroot(listDoc, "", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 doc (list wrapped, not flattened), got %d", len(result))
+	}
+	inner, ok := result[0].([]any)
+	if !ok {
+		t.Fatalf("expected list inside result[0], got %T", result[0])
+	}
+	if len(inner) != 3 {
+		t.Errorf("expected inner list of len 3, got %d", len(inner))
 	}
 }
 


### PR DESCRIPTION
<!-- PR title must follow: feat: / bug: / fix: / doc: / chore: / test: description -->

## What

Kill all 14 surviving mutants reported by gomutants in `pkg/diffyml/chroot.go`, leaving the file at 0 LIVED / 0 SUPPRESSED.

## Why

Per-PR mutation gate disallows LIVED mutants on changed lines, and the project's post-merge efficacy floor is 85.65%. `chroot.go` was a hotspot of survivors (14 across 8 distinct lines), pulling the package's efficacy down and hiding genuine test gaps in the path-navigation logic.

## How

Two commits:

1. **Add tests + directives** (`test: kill surviving mutants in pkg/diffyml/chroot.go`)
   - Seven new tests targeting the 9 reachable mutants:
     - `TestNavigateToPath_IndexOnNonList_ErrorMessage` — asserts `"expected list"` in the error so the L47 `!ok` branch can't be replaced with `_ = 0` and fall through to the bounds check (which would return `"out of bounds"` instead).
     - `TestNavigateToPath_NegativeIndex` — `"items[-1]"` would panic if `seg.index < 0` is removed.
     - `TestNavigateToPath_KeyThroughScalar_ErrorMessage` — asserts `"expected map"` so the type-switch default can't be replaced with `_ = 0` (which would fall through to `"key not found"`).
     - `TestParsePath_ExtraAfterBracket` — `"key[1]extra"` covers two L114 mutants at once.
     - `TestSplitPath_NestedOpenBracket` / `TestSplitPath_UnterminatedBracket` — direct splitPath edge cases.
     - `TestApplyChroot_EmptyPath_ListDoc_WrapsNotFlattens` — distinguishes the L190 early-return wrapping vs the general-path flattening when `listToDocuments=true`.
   - Refactored the L114 compound condition into three separate `if`s and added `// gomutants:disable-next-line` directives for the 5 unreachable / equivalent mutants (with justifications inline).

2. **Eliminate the directives entirely** (`refactor: replace suppressed mutants in chroot.go with code removal`)
   - Deleted the empty-path early-return guard clauses in `navigateToPath`, `parsePath`, and `applyChrootToDocs`. `parsePath("")` already does the right thing via `splitPath("")` → empty parts → skipped loop, so the guards were pure no-ops (equivalent mutants).
   - Replaced the two unreachable bracket-count checks plus the redundant `!HasSuffix` check with a single `strings.ContainsAny(indexStr, "[]")` on the extracted index string. `splitPath` ensures any `[` in a part is matched, so the only malformed shapes that survive are those that push `[` or `]` into the extracted `indexStr` (e.g. `key[0][1]`, `key[1]extra`). The new check kills both cases via one `BRANCH_IF`.

After both commits: chroot.go reports **69 KILLED, 0 LIVED, 0 SUPPRESSED**.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally (full pkg/diffyml test suite green)
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

- The second commit is a behavior-preserving refactor: every removed guard / check is replaced by an equivalent code path that produces the same observable result for all reachable inputs. The existing tests `TestParsePath_InvalidBracketSyntax` (`"key[0][1]"`) and `TestParsePath_EmptyListIndex` (`"key[]"`) still pass, plus the new `TestParsePath_ExtraAfterBracket` covers the `key[1]extra` shape.
- One subtle behavioral edge case: `applyChrootToDocs([]any{}, "", _)` used to return the input empty slice unchanged; it now returns `nil`. Both have `len == 0`, and no caller (or test) appears to distinguish.
- Project-wide suppressed mutant count goes 13 → 18 → 13 across the two commits (added then removed the 5 directives).