### PR TITLE
test: kill surviving mutants in pkg/diffyml/comparator.go

### DIFF
--- a/pkg/diffyml/benchmark_test.go
+++ b/pkg/diffyml/benchmark_test.go
@@ -445,7 +445,7 @@ func BenchmarkCompareOrderedMaps(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				compareOrderedMaps(DiffPath{"root"}, from, to, nil)
+				compareOrderedMaps(DiffPath{"root"}, from, to, &Options{})
 			}
 		})
 	}
@@ -465,7 +465,7 @@ func BenchmarkCompareLists_ByIdentifier(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				compareListsByIdentifier(DiffPath{"services"}, from, to, nil)
+				compareListsByIdentifier(DiffPath{"services"}, from, to, &Options{})
 			}
 		})
 	}
@@ -481,7 +481,7 @@ func BenchmarkCompareLists_Unordered(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				compareListsUnordered(DiffPath{"items"}, from, to, nil)
+				compareListsUnordered(DiffPath{"items"}, from, to, &Options{})
 			}
 		})
 	}
@@ -521,7 +521,7 @@ func BenchmarkDeepEqual(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			deepEqual(om, om, nil)
+			deepEqual(om, om, &Options{})
 		}
 	})
 
@@ -531,7 +531,7 @@ func BenchmarkDeepEqual(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			deepEqual(om1, om2, nil)
+			deepEqual(om1, om2, &Options{})
 		}
 	})
 
@@ -541,7 +541,7 @@ func BenchmarkDeepEqual(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			deepEqual(nested1, nested2, nil)
+			deepEqual(nested1, nested2, &Options{})
 		}
 	})
 }

--- a/pkg/diffyml/comparator.go
+++ b/pkg/diffyml/comparator.go
@@ -17,9 +17,9 @@ import (
 )
 
 // compareDocs compares two slices of YAML documents and returns differences.
+// opts is non-nil — Compare normalizes it before calling.
 func compareDocs(from, to []any, opts *Options) []Difference {
-	// Check if Kubernetes detection is enabled and documents are K8s resources
-	if opts != nil && opts.DetectKubernetes && hasK8sDocuments(from, to) {
+	if opts.DetectKubernetes && hasK8sDocuments(from, to) {
 		return compareK8sDocs(from, to, opts)
 	}
 
@@ -71,8 +71,11 @@ func hasK8sDocuments(from, to []any) bool {
 }
 
 // compareNodeNils handles nil cases for compareNodes.
-// Returns diffs and true if an early return is appropriate.
-func compareNodeNils(path DiffPath, from, to any, opts *Options) ([]Difference, bool) {
+// Returns diffs and true if an early return is appropriate. The to==nil case
+// is intentionally not short-circuited here — the caller's type-switch and
+// type-mismatch fallthrough produce the same DiffModified output, so handling
+// it twice would be dead code.
+func compareNodeNils(path DiffPath, from, to any) ([]Difference, bool) {
 	if from == nil && to == nil {
 		return nil, true
 	}
@@ -84,23 +87,12 @@ func compareNodeNils(path DiffPath, from, to any, opts *Options) ([]Difference, 
 			To:   to,
 		}}, true
 	}
-	if to == nil {
-		if opts != nil && opts.IgnoreValueChanges {
-			return nil, true
-		}
-		return []Difference{{
-			Path: path,
-			Type: DiffModified,
-			From: from,
-			To:   nil,
-		}}, true
-	}
 	return nil, false
 }
 
-// compareNodes recursively compares two YAML nodes.
+// compareNodes recursively compares two YAML nodes. opts is non-nil.
 func compareNodes(path DiffPath, from, to any, opts *Options) []Difference {
-	if diffs, done := compareNodeNils(path, from, to, opts); done {
+	if diffs, done := compareNodeNils(path, from, to); done {
 		return diffs
 	}
 
@@ -122,7 +114,7 @@ func compareNodes(path DiffPath, from, to any, opts *Options) []Difference {
 		// Both are scalars — check if same concrete type
 		if sameScalarType(from, to) {
 			if !equalValues(from, to, opts) {
-				if opts != nil && opts.IgnoreValueChanges {
+				if opts.IgnoreValueChanges {
 					return nil
 				}
 				return []Difference{{
@@ -136,8 +128,8 @@ func compareNodes(path DiffPath, from, to any, opts *Options) []Difference {
 		}
 	}
 
-	// Type mismatch
-	if opts != nil && opts.IgnoreValueChanges {
+	// Type mismatch (includes to==nil after the nil-pair short-circuits)
+	if opts.IgnoreValueChanges {
 		return nil
 	}
 	return []Difference{{
@@ -272,7 +264,7 @@ func compareLists(path DiffPath, from, to []any, opts *Options) []Difference {
 	}
 
 	// If explicitly ignoring order, compare as sets
-	if opts != nil && opts.IgnoreOrderChanges {
+	if opts.IgnoreOrderChanges {
 		return compareListsUnordered(path, from, to, opts)
 	}
 
@@ -310,12 +302,10 @@ func areListItemsHeterogeneous(from, to []any) bool {
 	extractKeys(from)
 	extractKeys(to)
 
-	// If we don't have map items, not heterogeneous
-	if len(allKeys) == 0 {
-		return false
-	}
-
-	// Check if each map item uses a distinct set of keys (only one key per item)
+	// Check if each map item uses a distinct set of keys (only one key per item).
+	// When no map items are present, checkSingleDistinctKeys returns false on
+	// the non-map item (or true on an empty list), and the final `len(allKeys) > 1`
+	// guard returns false either way — no separate empty-allKeys short-circuit needed.
 	// This is a heuristic: items with single, different keys are likely heterogeneous
 	// (e.g., {namespaceSelector: ...} vs {ipBlock: ...})
 	checkSingleDistinctKeys := func(list []any) bool {
@@ -481,16 +471,14 @@ func detectListOrderChanges(path DiffPath, fromIDs []any, fromIndex, toIndex map
 		}
 	}
 
-	if len(commonFromOrder) < 2 {
-		return nil
-	}
-
-	// Build to-order for the common identifiers
+	// Build to-order for the common identifiers. With fewer than 2 common
+	// items the order can't differ; the orderChanged check below returns nil
+	// for that case, so no separate short-circuit is needed.
 	type idxID struct {
 		idx int
 		id  any
 	}
-	var toSorted []idxID
+	toSorted := make([]idxID, 0, len(commonFromOrder))
 	for _, id := range commonFromOrder {
 		toSorted = append(toSorted, idxID{toIndex[id], id})
 	}
@@ -498,15 +486,9 @@ func detectListOrderChanges(path DiffPath, fromIDs []any, fromIndex, toIndex map
 		return cmp.Compare(a.idx, b.idx)
 	})
 
-	// Check if from-order and to-order differ
-	orderChanged := false
-	for i, id := range commonFromOrder {
-		if id != toSorted[i].id {
-			orderChanged = true
-			break
-		}
-	}
-
+	orderChanged := !slices.EqualFunc(commonFromOrder, toSorted, func(a any, b idxID) bool {
+		return a == b.id
+	})
 	if !orderChanged {
 		return nil
 	}
@@ -612,7 +594,7 @@ func compareListsByIdentifier(path DiffPath, from, to []any, opts *Options) []Di
 	}
 
 	// Detect order changes among matched identifiers.
-	if opts == nil || !opts.IgnoreOrderChanges {
+	if !opts.IgnoreOrderChanges {
 		if orderDiff := detectListOrderChanges(path, fromIDs, fromIndex, toIndex, toIDCount); orderDiff != nil {
 			diffs = append(diffs, *orderDiff)
 		}
@@ -755,14 +737,13 @@ func deepEqualSlices(from, to []any, opts *Options) bool {
 }
 
 // deepEqual compares two values deeply with options.
+//
+// nil handling, type mismatches, and same-type scalar comparison are all
+// delegated to the type-switch + equalValues: a nil `to` makes each case's
+// `ok` assertion fail (returning false); a nil `from` lands in the default
+// branch where equalValues returns `from == to`, which is true for both-nil
+// and false for any mixed case or type mismatch.
 func deepEqual(from, to any, opts *Options) bool {
-	if from == nil && to == nil {
-		return true
-	}
-	if from == nil || to == nil {
-		return false
-	}
-
 	switch fromVal := from.(type) {
 	case *OrderedMap:
 		if toVal, ok := to.(*OrderedMap); ok {
@@ -780,9 +761,6 @@ func deepEqual(from, to any, opts *Options) bool {
 		}
 		return false
 	default:
-		if !sameScalarType(from, to) {
-			return false
-		}
 		return equalValues(from, to, opts)
 	}
 }

--- a/pkg/diffyml/compare_test.go
+++ b/pkg/diffyml/compare_test.go
@@ -2701,3 +2701,547 @@ func TestCompare_DuplicateListEntries(t *testing.T) {
 		t.Errorf("expected DiffAdded, got %v", diffs[0].Type)
 	}
 }
+
+// --- Mutation testing: comparator.go ---
+
+// hasK8sDocuments must short-circuit on the first K8s resource found in `from`,
+// even when `to` contains no K8s resources. Without the early return, the from
+// loop completes and the to loop returns false, taking the generic path and
+// producing key-level diffs instead of the K8s doc-level remove/add.
+func TestCompare_K8sDetection_OnlyFromHasResources(t *testing.T) {
+	from := yml(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-a
+data:
+  key: value`)
+	to := yml(`unrelated: scalar`)
+
+	diffs, err := compare(from, to, &diffyml.Options{DetectKubernetes: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	// Only the K8s path stamps DocumentKind on resource-level diffs.
+	foundCMKind := false
+	for _, d := range diffs {
+		if d.DocumentKind == "ConfigMap" {
+			foundCMKind = true
+		}
+	}
+	if !foundCMKind {
+		t.Errorf("expected a diff carrying DocumentKind=ConfigMap (K8s compare path), got %+v", diffs)
+	}
+}
+
+// Both root documents parse to nil — compareNodeNils must short-circuit, not
+// fall through to the from==nil branch and emit a bogus DiffAdded.
+func TestCompare_BothNullDocuments_NoDiffs(t *testing.T) {
+	from := yml(`~`)
+	to := yml(`~`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Fatalf("expected 0 diffs for null vs null, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// canMatchByIdentifier must return false on either side independently. With
+// `from` carrying name keys but `to` carrying none (both all-map lists),
+// taking the ID-matching path produces list-level Remove+Add at the parent
+// "items" path. Positional compare instead drills into a Modified at
+// "items.0.value", which is the assertion below.
+func TestCompare_IdentifierMatching_AsymmetricSides(t *testing.T) {
+	tests := []struct {
+		name string
+		from string
+		to   string
+	}{
+		{
+			name: "from has name, to does not",
+			from: `items:
+  - name: foo
+    value: 1`,
+			to: `items:
+  - other: bar
+    value: 2`,
+		},
+		{
+			name: "from has no name, to has name",
+			from: `items:
+  - other: bar
+    value: 1`,
+			to: `items:
+  - name: foo
+    value: 2`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diffs, err := compare(yml(tt.from), yml(tt.to), nil)
+			if err != nil {
+				t.Fatalf("compare() failed: %v", err)
+			}
+			foundValuePath := false
+			for _, d := range diffs {
+				if strings.Contains(d.Path.String(), "value") {
+					foundValuePath = true
+				}
+			}
+			if !foundValuePath {
+				t.Errorf("expected positional Modified under '.value' path, got %+v", diffs)
+			}
+		})
+	}
+}
+
+// areListItemsHeterogeneous: OrderedMap items with multiple keys must NOT be
+// treated as heterogeneous (the single-key heuristic doesn't apply). Swapping
+// them should produce diffs under positional comparison; the mutated case
+// body would silently exact-match the swap under unordered comparison.
+func TestCompare_HeterogeneityCheck_MultiKeyOrderedMapIsHomogeneous(t *testing.T) {
+	from := yml(`rules:
+  - a: 1
+    b: 2
+  - c: 3
+    d: 4`)
+	to := yml(`rules:
+  - c: 3
+    d: 4
+  - a: 1
+    b: 2`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if len(diffs) == 0 {
+		t.Fatal("expected diffs from positional compare of swapped multi-key items, got 0")
+	}
+}
+
+// areListItemsHeterogeneous: a non-map (scalar) item must break the
+// single-key heuristic via the default case. With allKeys spanning multiple
+// distinct map keys, the original returns false (homogeneous → positional);
+// the mutated default returns true (heterogeneous → unordered) and matches
+// the swapped maps exactly, hiding the scalar Modified at index 0.
+func TestCompare_HeterogeneityCheck_ScalarItemBreaksHomogeneity(t *testing.T) {
+	from := yml(`items:
+  - 1
+  - a: 1
+  - b: 1`)
+	to := yml(`items:
+  - 2
+  - b: 1
+  - a: 1`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	// Positional compare yields a diff at items.1 (a:1 vs b:1) AND at items.2.
+	// Heterogeneous unordered would exact-match those swaps and only diff items.0.
+	foundIndex1Or2 := false
+	for _, d := range diffs {
+		p := d.Path.String()
+		if strings.HasPrefix(p, "items.1") || strings.HasPrefix(p, "items.2") {
+			foundIndex1Or2 = true
+		}
+	}
+	if !foundIndex1Or2 {
+		t.Errorf("expected positional diff under items.1 or items.2, got %+v", diffs)
+	}
+}
+
+// areListItemsHeterogeneous: checkSingleDistinctKeys(to) must veto the
+// heterogeneous classification when `to` carries a multi-key item. The
+// mutant forcing it to true would re-route to unordered comparison and
+// hide swap-induced diffs.
+func TestCompare_HeterogeneityCheck_AsymmetricSingleKeyShape(t *testing.T) {
+	from := yml(`items:
+  - a: 1
+  - b: 2
+  - c: 3`)
+	to := yml(`items:
+  - x: 1
+    y: 2
+  - a: 1
+  - b: 2`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	// Positional compare emits per-key Removed+Added at items.0 plus
+	// shape-changes at items.1, items.2. Unordered heterogeneous would
+	// exact-match {a:1} and {b:2} and only diff items.0 (or items.2).
+	pathSet := map[string]bool{}
+	for _, d := range diffs {
+		pathSet[d.Path.String()] = true
+	}
+	// Look for diffs at multiple item indexes to confirm positional path.
+	count := 0
+	for p := range pathSet {
+		if strings.HasPrefix(p, "items.0") || strings.HasPrefix(p, "items.1") || strings.HasPrefix(p, "items.2") {
+			count++
+		}
+	}
+	if count < 2 {
+		t.Errorf("expected diffs at multiple items.N paths (positional), got %+v", diffs)
+	}
+}
+
+// compareListsUnordered must skip already-matched to-items in the exact-match
+// scan. With duplicate "a" in `from` and a single "a" in `to`, the second
+// from-"a" must remain unmatched and surface as DiffRemoved.
+func TestCompare_IgnoreOrder_DuplicatesFromSide(t *testing.T) {
+	from := yml(`items: [a, a]`)
+	to := yml(`items: [a]`)
+
+	diffs, err := compare(from, to, &diffyml.Options{IgnoreOrderChanges: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if !hasDiffType(diffs, diffyml.DiffRemoved) {
+		t.Errorf("expected DiffRemoved for the second duplicate, got %+v", diffs)
+	}
+}
+
+// compareListsUnordered must `break` after pairing fromItem[i] with one
+// toItem[j]. If `break` becomes `continue`, the same fromItem keeps matching
+// further toItems and hides the second-duplicate DiffAdded.
+func TestCompare_IgnoreOrder_DuplicatesToSide(t *testing.T) {
+	from := yml(`items: [a]`)
+	to := yml(`items: [a, a]`)
+
+	diffs, err := compare(from, to, &diffyml.Options{IgnoreOrderChanges: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if !hasDiffType(diffs, diffyml.DiffAdded) {
+		t.Errorf("expected DiffAdded for the second duplicate, got %+v", diffs)
+	}
+}
+
+// compareListsUnordered trailing fi cleanup must `continue` past matched
+// indices, not `break`. With fromMatched=[F,T,F], breaking on index 1 would
+// drop the Removed for index 2 ("c").
+func TestCompare_IgnoreOrder_UnmatchedAfterMatchedFromIdx(t *testing.T) {
+	from := yml(`items: [a, b, c]`)
+	to := yml(`items: [b]`)
+
+	diffs, err := compare(from, to, &diffyml.Options{IgnoreOrderChanges: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	removed := 0
+	for _, d := range diffs {
+		if d.Type == diffyml.DiffRemoved {
+			removed++
+		}
+	}
+	if removed != 2 {
+		t.Errorf("expected 2 DiffRemoved for unmatched a and c, got %d (%+v)", removed, diffs)
+	}
+}
+
+// Mirror of the previous test for the `to` cleanup loop.
+func TestCompare_IgnoreOrder_UnmatchedAfterMatchedToIdx(t *testing.T) {
+	from := yml(`items: [b]`)
+	to := yml(`items: [a, b, c]`)
+
+	diffs, err := compare(from, to, &diffyml.Options{IgnoreOrderChanges: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	added := 0
+	for _, d := range diffs {
+		if d.Type == diffyml.DiffAdded {
+			added++
+		}
+	}
+	if added != 2 {
+		t.Errorf("expected 2 DiffAdded for unmatched a and c, got %d (%+v)", added, diffs)
+	}
+}
+
+// detectListOrderChanges must skip its order-change report when identifiers
+// are not unique on either side. Two from-items share name=a, so the
+// duplicate-detection guard `hasUniqueIDs` is false and no DiffOrderChanged
+// should be emitted (regardless of from/to ordering).
+func TestCompare_OrderChange_SkippedWhenDuplicateIdentifiers(t *testing.T) {
+	from := yml(`items:
+  - name: a
+    v: 1
+  - name: a
+    v: 2
+  - name: b
+    v: 3`)
+	to := yml(`items:
+  - name: b
+    v: 3
+  - name: a
+    v: 1
+  - name: a
+    v: 2`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	for _, d := range diffs {
+		if d.Type == diffyml.DiffOrderChanged {
+			t.Errorf("did not expect DiffOrderChanged with duplicate identifiers, got %+v", d)
+		}
+	}
+}
+
+// compareUnidentifiedItems must skip already-matched to-items in the
+// exact-match scan (mirror of the compareListsUnordered case). Reached via a
+// mixed-identifier list where {foo:1} entries fall into the unidentified
+// fallback.
+func TestCompare_MixedIdentifierList_DuplicateUnidentifiedItems(t *testing.T) {
+	from := yml(`items:
+  - name: keep
+    v: 1
+  - foo: 1
+  - foo: 1`)
+	to := yml(`items:
+  - name: keep
+    v: 1
+  - foo: 1`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if !hasDiffType(diffs, diffyml.DiffRemoved) {
+		t.Errorf("expected DiffRemoved for the second {foo:1}, got %+v", diffs)
+	}
+}
+
+// Mirror for the to-side cleanup loop in compareUnidentifiedItems.
+func TestCompare_MixedIdentifierList_ToSideHasExtraUnidentified(t *testing.T) {
+	from := yml(`items:
+  - name: keep
+    v: 1
+  - foo: 1`)
+	to := yml(`items:
+  - name: keep
+    v: 1
+  - foo: 1
+  - foo: 1`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if !hasDiffType(diffs, diffyml.DiffAdded) {
+		t.Errorf("expected DiffAdded for the extra {foo:1}, got %+v", diffs)
+	}
+}
+
+// Drives the fromNoIDMatched-skip in the compareUnidentifiedItems cleanup
+// loop: a matched unidentified item is sandwiched between two unmatched
+// ones, so `continue` (not `break`) is required to surface both.
+func TestCompare_MixedIdentifierList_UnmatchedAroundMatched(t *testing.T) {
+	from := yml(`items:
+  - name: keep
+    v: 1
+  - x: 1
+  - y: 2
+  - z: 3`)
+	to := yml(`items:
+  - name: keep
+    v: 1
+  - y: 2`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	removed := 0
+	for _, d := range diffs {
+		if d.Type == diffyml.DiffRemoved {
+			removed++
+		}
+	}
+	if removed < 2 {
+		t.Errorf("expected at least 2 DiffRemoved (x:1 and z:3), got %d (%+v)", removed, diffs)
+	}
+}
+
+// couldBeJSON must require a leading '{' or '[' — not just len>=2.
+// "123" and "123 " both unmarshal as JSON numbers and canonicalize equal;
+// with the start-char check mutated to `true`, they'd be reported equal
+// and the diff would disappear.
+func TestCompare_FormatStrings_NonJSONShapedStringsStillDiff(t *testing.T) {
+	from := yml(`data: "123"`)
+	to := yml(`data: "123 "`)
+
+	diffs, err := compare(from, to, &diffyml.Options{FormatStrings: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for non-JSON-shaped strings, got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// compareListsUnordered walk loop must `continue` past an already-matched
+// fromMatched[fi]. With break, a leading exact match would stop the
+// pair-walk entirely and convert the remaining "modified" item into a
+// spurious Remove+Add at the same path.
+func TestCompare_IgnoreOrder_WalkSkipsMatchedFromPrefix(t *testing.T) {
+	from := yml(`items: [a, b]`)
+	to := yml(`items: [a, c]`)
+
+	diffs, err := compare(from, to, &diffyml.Options{IgnoreOrderChanges: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff (b→c modified), got %d: %+v", len(diffs), diffs)
+	}
+	if diffs[0].Type != diffyml.DiffModified {
+		t.Errorf("expected DiffModified (walk should pair b and c), got %v", diffs[0].Type)
+	}
+}
+
+// compareUnidentifiedItems walk loop must `continue` past an already-matched
+// fromNoIDMatched[fi]. Same shape as the previous test but routed through
+// the mixed-identifier fallback.
+func TestCompare_MixedIdentifierList_WalkSkipsMatchedFromPrefix(t *testing.T) {
+	from := yml(`items:
+  - name: keep
+  - match: 1
+  - value: 1`)
+	to := yml(`items:
+  - name: keep
+  - match: 1
+  - value: 2`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	for _, d := range diffs {
+		if d.Type == diffyml.DiffRemoved || d.Type == diffyml.DiffAdded {
+			t.Errorf("expected pure DiffModified (walk should pair value:1 and value:2), got %v at %s", d.Type, d.Path)
+		}
+	}
+	if !hasDiffType(diffs, diffyml.DiffModified) {
+		t.Errorf("expected DiffModified at items.2.value, got %+v", diffs)
+	}
+}
+
+// compareUnidentifiedItems inner scan must `continue` past an already-matched
+// toNoIDMatched[tj], not `break`. Breaking would prevent a later fromItem
+// from finding its real match further down the toNoID slice.
+func TestCompare_MixedIdentifierList_InnerScanSkipsMatchedToPrefix(t *testing.T) {
+	from := yml(`items:
+  - name: keep
+  - a: 1
+  - b: 1
+  - c: 1`)
+	to := yml(`items:
+  - name: keep
+  - a: 1
+  - c: 1
+  - b: 1`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if len(diffs) != 0 {
+		t.Fatalf("expected 0 diffs (all items match exactly across order), got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// detectListOrderChanges' hasUniqueIDs guard combines two checks with &&.
+// Asymmetric tests (one side has duplicate IDs, the other unique) prevent
+// either operand from being silently mutated to `true`, and prevent
+// `&&` → `||` from passing the guard.
+func TestCompare_OrderChange_DuplicateFromUniqueTo(t *testing.T) {
+	from := yml(`items:
+  - name: a
+  - name: a
+  - name: b`)
+	to := yml(`items:
+  - name: b
+  - name: a
+  - name: c`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	for _, d := range diffs {
+		if d.Type == diffyml.DiffOrderChanged {
+			t.Errorf("did not expect DiffOrderChanged when from has duplicate IDs, got %+v", d)
+		}
+	}
+}
+
+func TestCompare_OrderChange_UniqueFromDuplicateTo(t *testing.T) {
+	from := yml(`items:
+  - name: a
+  - name: b
+  - name: c`)
+	to := yml(`items:
+  - name: c
+  - name: a
+  - name: a`)
+
+	diffs, err := compare(from, to, nil)
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	for _, d := range diffs {
+		if d.Type == diffyml.DiffOrderChanged {
+			t.Errorf("did not expect DiffOrderChanged when to has duplicate IDs, got %+v", d)
+		}
+	}
+}
+
+// couldBeJSON's length guard must short-circuit before indexing s[0].
+// Mutating `len(s) >= 2` to `true` (or `&&` to `||`) would access s[0]
+// on an empty string and panic.
+func TestCompare_FormatStrings_EmptyStringNoPanic(t *testing.T) {
+	from := yml(`data: ""`)
+	to := yml(`data: "x"`)
+
+	diffs, err := compare(from, to, &diffyml.Options{FormatStrings: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for empty vs 'x', got %d: %+v", len(diffs), diffs)
+	}
+}
+
+// deepEqualOrderedMaps must reject a size mismatch up front. With the length
+// guard removed, a subset map would be wrongly considered equal to a
+// superset in the exact-match scan of unordered list comparison.
+func TestCompare_IgnoreOrder_SupersetMapMustNotMatchExactly(t *testing.T) {
+	from := yml(`items:
+  - a: 1`)
+	to := yml(`items:
+  - a: 1
+    b: 2`)
+
+	diffs, err := compare(from, to, &diffyml.Options{IgnoreOrderChanges: true})
+	if err != nil {
+		t.Fatalf("compare() failed: %v", err)
+	}
+	if len(diffs) == 0 {
+		t.Fatal("expected at least 1 diff for the added key b, got 0")
+	}
+	if !hasDiffType(diffs, diffyml.DiffAdded) {
+		t.Errorf("expected DiffAdded for new key b, got %+v", diffs)
+	}
+}

--- a/pkg/diffyml/coverage_gaps_test.go
+++ b/pkg/diffyml/coverage_gaps_test.go
@@ -17,7 +17,7 @@ import (
 func TestDeepEqual_OrderedMaps_DifferentLengths(t *testing.T) {
 	a := &OrderedMap{Values: map[string]any{"x": 1, "y": 2}}
 	b := &OrderedMap{Values: map[string]any{"x": 1}}
-	if deepEqual(a, b, nil) {
+	if deepEqual(a, b, &Options{}) {
 		t.Error("expected OrderedMaps with different lengths to not be deepEqual")
 	}
 }
@@ -27,7 +27,7 @@ func TestDeepEqual_OrderedMaps_DifferentLengths(t *testing.T) {
 func TestDeepEqual_Slices_Equal(t *testing.T) {
 	a := []any{"x", "y", "z"}
 	b := []any{"x", "y", "z"}
-	if !deepEqual(a, b, nil) {
+	if !deepEqual(a, b, &Options{}) {
 		t.Error("expected equal slices to be deepEqual")
 	}
 }
@@ -35,7 +35,7 @@ func TestDeepEqual_Slices_Equal(t *testing.T) {
 func TestDeepEqual_Slices_DifferentValues(t *testing.T) {
 	a := []any{"x", "y"}
 	b := []any{"x", "z"}
-	if deepEqual(a, b, nil) {
+	if deepEqual(a, b, &Options{}) {
 		t.Error("expected slices with different values to not be deepEqual")
 	}
 }
@@ -43,7 +43,7 @@ func TestDeepEqual_Slices_DifferentValues(t *testing.T) {
 func TestDeepEqual_Slices_DifferentLengths(t *testing.T) {
 	a := []any{"x"}
 	b := []any{"x", "y"}
-	if deepEqual(a, b, nil) {
+	if deepEqual(a, b, &Options{}) {
 		t.Error("expected slices with different lengths to not be deepEqual")
 	}
 }
@@ -51,7 +51,7 @@ func TestDeepEqual_Slices_DifferentLengths(t *testing.T) {
 func TestDeepEqual_Slices_Nested(t *testing.T) {
 	a := []any{[]any{"a", "b"}}
 	b := []any{[]any{"a", "b"}}
-	if !deepEqual(a, b, nil) {
+	if !deepEqual(a, b, &Options{}) {
 		t.Error("expected nested equal slices to be deepEqual")
 	}
 }
@@ -225,7 +225,7 @@ func TestCompareListsByIdentifier_NoIDFallback(t *testing.T) {
 		"shared-scalar",
 	}
 
-	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, nil)
+	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, &Options{})
 
 	// "a" matched by name → modified value (1 → 2)
 	// "shared-scalar" matched by deepEqual in fallback → no diff
@@ -497,7 +497,7 @@ func TestComputeLineDiff_IdenticalLines(t *testing.T) {
 func TestCompareListsPositional_ToLonger(t *testing.T) {
 	from := []any{"a", "b"}
 	to := []any{"a", "b", "c", "d"}
-	diffs := compareListsPositional(DiffPath{"list"}, from, to, nil)
+	diffs := compareListsPositional(DiffPath{"list"}, from, to, &Options{})
 
 	added := 0
 	for _, d := range diffs {
@@ -513,7 +513,7 @@ func TestCompareListsPositional_ToLonger(t *testing.T) {
 func TestCompareListsPositional_FromLonger(t *testing.T) {
 	from := []any{"a", "b", "c"}
 	to := []any{"a"}
-	diffs := compareListsPositional(DiffPath{"list"}, from, to, nil)
+	diffs := compareListsPositional(DiffPath{"list"}, from, to, &Options{})
 
 	removed := 0
 	for _, d := range diffs {
@@ -614,13 +614,13 @@ func TestGetIdentifier_PlainMap(t *testing.T) {
 }
 
 func TestDeepEqual_BothNil(t *testing.T) {
-	if !deepEqual(nil, nil, nil) {
-		t.Error("deepEqual(nil, nil) should be true")
+	if !deepEqual(nil, nil, &Options{}) {
+		t.Error("deepEqual(nil, &Options{}) should be true")
 	}
 }
 
 func TestDeepEqual_TypeMismatch(t *testing.T) {
-	if deepEqual("str", 42, nil) {
+	if deepEqual("str", 42, &Options{}) {
 		t.Error("deepEqual with different types should be false")
 	}
 }
@@ -646,7 +646,7 @@ func TestCompareListsByIdentifier_NoIDMatchedSkip(t *testing.T) {
 		"shared-b",
 	}
 
-	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, nil)
+	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, &Options{})
 	for _, d := range diffs {
 		if d.Type == DiffRemoved || d.Type == DiffAdded {
 			t.Errorf("unexpected diff: %+v", d)
@@ -673,7 +673,7 @@ func TestCompareListsByIdentifier_NoIDExcessAdded(t *testing.T) {
 		"new-b",
 	}
 
-	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, nil)
+	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, &Options{})
 
 	// "only-in-from" vs "new-a" → positional modification
 	// "new-b" has no counterpart → added
@@ -715,7 +715,7 @@ func TestCompareUnidentifiedItems_CursorSkipMatchedTo(t *testing.T) {
 		"only-to",
 	}
 
-	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, nil)
+	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, &Options{})
 
 	// "shared" matches exactly. Remaining: "only-from" vs "only-to" → modification.
 	var modified int
@@ -750,7 +750,7 @@ func TestCompareUnidentifiedItems_ExcessFromWithMatchedSkip(t *testing.T) {
 		"shared",
 	}
 
-	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, nil)
+	diffs := compareListsByIdentifier(DiffPath{"items"}, from, to, &Options{})
 
 	// "shared" matches exactly. Remaining from: ["removed-a", "removed-b"] vs to: [].
 	// Both are excess → 2 modifications? No — no to items left, so "removed-a" has
@@ -1103,30 +1103,30 @@ func TestDeepEqual_TypeMismatch_OrderedMapVsString(t *testing.T) {
 	om := NewOrderedMap()
 	om.Keys = append(om.Keys, "k")
 	om.Values["k"] = "v"
-	if deepEqual(om, "not-a-map", nil) {
+	if deepEqual(om, "not-a-map", &Options{}) {
 		t.Error("expected false for *OrderedMap vs string")
 	}
 }
 
 func TestDeepEqual_TypeMismatch_MapVsString(t *testing.T) {
 	m := map[string]any{"k": "v"}
-	if deepEqual(m, "not-a-map", nil) {
+	if deepEqual(m, "not-a-map", &Options{}) {
 		t.Error("expected false for map vs string")
 	}
 }
 
 func TestDeepEqual_TypeMismatch_SliceVsString(t *testing.T) {
 	s := []any{"a", "b"}
-	if deepEqual(s, "not-a-slice", nil) {
+	if deepEqual(s, "not-a-slice", &Options{}) {
 		t.Error("expected false for slice vs string")
 	}
 }
 
 func TestDeepEqual_TypeMismatch_ScalarTypes(t *testing.T) {
-	if deepEqual("hello", 42, nil) {
+	if deepEqual("hello", 42, &Options{}) {
 		t.Error("expected false for string vs int")
 	}
-	if deepEqual(3.14, true, nil) {
+	if deepEqual(3.14, true, &Options{}) {
 		t.Error("expected false for float64 vs bool")
 	}
 }

--- a/pkg/diffyml/plainmap_coverage_test.go
+++ b/pkg/diffyml/plainmap_coverage_test.go
@@ -15,7 +15,7 @@ func TestCompareNodes_PlainMaps_Equal(t *testing.T) {
 	from := map[string]any{"a": "1", "b": "2"}
 	to := map[string]any{"a": "1", "b": "2"}
 
-	diffs := compareNodes(DiffPath{"root"}, from, to, nil)
+	diffs := compareNodes(DiffPath{"root"}, from, to, &Options{})
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs for equal plain maps, got %d: %v", len(diffs), diffs)
 	}
@@ -25,7 +25,7 @@ func TestCompareNodes_PlainMaps_Modified(t *testing.T) {
 	from := map[string]any{"a": "1", "b": "2"}
 	to := map[string]any{"a": "1", "b": "changed"}
 
-	diffs := compareNodes(DiffPath{"root"}, from, to, nil)
+	diffs := compareNodes(DiffPath{"root"}, from, to, &Options{})
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
 	}
@@ -41,7 +41,7 @@ func TestCompareNodes_PlainMaps_Added(t *testing.T) {
 	from := map[string]any{"a": "1"}
 	to := map[string]any{"a": "1", "b": "2"}
 
-	diffs := compareNodes(DiffPath{"root"}, from, to, nil)
+	diffs := compareNodes(DiffPath{"root"}, from, to, &Options{})
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
 	}
@@ -54,7 +54,7 @@ func TestCompareNodes_PlainMaps_Removed(t *testing.T) {
 	from := map[string]any{"a": "1", "b": "2"}
 	to := map[string]any{"a": "1"}
 
-	diffs := compareNodes(DiffPath{"root"}, from, to, nil)
+	diffs := compareNodes(DiffPath{"root"}, from, to, &Options{})
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
 	}
@@ -71,7 +71,7 @@ func TestCompareNodes_PlainMaps_Nested(t *testing.T) {
 		"parent": map[string]any{"child": "new"},
 	}
 
-	diffs := compareNodes(nil, from, to, nil)
+	diffs := compareNodes(nil, from, to, &Options{})
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d: %v", len(diffs), diffs)
 	}
@@ -86,7 +86,7 @@ func TestDeepEqual_PlainMaps_Equal(t *testing.T) {
 	a := map[string]any{"x": "1", "y": "2"}
 	b := map[string]any{"x": "1", "y": "2"}
 
-	if !deepEqual(a, b, nil) {
+	if !deepEqual(a, b, &Options{}) {
 		t.Error("expected equal plain maps to be deepEqual")
 	}
 }
@@ -95,7 +95,7 @@ func TestDeepEqual_PlainMaps_DifferentValues(t *testing.T) {
 	a := map[string]any{"x": "1"}
 	b := map[string]any{"x": "2"}
 
-	if deepEqual(a, b, nil) {
+	if deepEqual(a, b, &Options{}) {
 		t.Error("expected different plain maps to not be deepEqual")
 	}
 }
@@ -104,7 +104,7 @@ func TestDeepEqual_PlainMaps_DifferentKeys(t *testing.T) {
 	a := map[string]any{"x": "1"}
 	b := map[string]any{"y": "1"}
 
-	if deepEqual(a, b, nil) {
+	if deepEqual(a, b, &Options{}) {
 		t.Error("expected maps with different keys to not be deepEqual")
 	}
 }
@@ -113,7 +113,7 @@ func TestDeepEqual_PlainMaps_DifferentLengths(t *testing.T) {
 	a := map[string]any{"x": "1"}
 	b := map[string]any{"x": "1", "y": "2"}
 
-	if deepEqual(a, b, nil) {
+	if deepEqual(a, b, &Options{}) {
 		t.Error("expected maps with different lengths to not be deepEqual")
 	}
 }
@@ -122,7 +122,7 @@ func TestDeepEqual_PlainMaps_Nested(t *testing.T) {
 	a := map[string]any{"m": map[string]any{"k": "v"}}
 	b := map[string]any{"m": map[string]any{"k": "v"}}
 
-	if !deepEqual(a, b, nil) {
+	if !deepEqual(a, b, &Options{}) {
 		t.Error("expected nested equal plain maps to be deepEqual")
 	}
 }
@@ -131,7 +131,7 @@ func TestDeepEqual_PlainMaps_NestedDifferent(t *testing.T) {
 	a := map[string]any{"m": map[string]any{"k": "v1"}}
 	b := map[string]any{"m": map[string]any{"k": "v2"}}
 
-	if deepEqual(a, b, nil) {
+	if deepEqual(a, b, &Options{}) {
 		t.Error("expected nested different plain maps to not be deepEqual")
 	}
 }
@@ -142,7 +142,7 @@ func TestCompareListsPositional_ItemsAdded(t *testing.T) {
 	from := []any{"a"}
 	to := []any{"a", "b", "c"}
 
-	diffs := compareListsPositional(DiffPath{"list"}, from, to, nil)
+	diffs := compareListsPositional(DiffPath{"list"}, from, to, &Options{})
 
 	added := 0
 	for _, d := range diffs {
@@ -159,7 +159,7 @@ func TestCompareListsPositional_ItemsRemoved(t *testing.T) {
 	from := []any{"a", "b", "c"}
 	to := []any{"a"}
 
-	diffs := compareListsPositional(DiffPath{"list"}, from, to, nil)
+	diffs := compareListsPositional(DiffPath{"list"}, from, to, &Options{})
 
 	removed := 0
 	for _, d := range diffs {
@@ -176,7 +176,7 @@ func TestCompareListsPositional_BothAddedAndRemoved(t *testing.T) {
 	from := []any{"a", "b"}
 	to := []any{"x", "y", "z"}
 
-	diffs := compareListsPositional(DiffPath{"list"}, from, to, nil)
+	diffs := compareListsPositional(DiffPath{"list"}, from, to, &Options{})
 
 	var modified, added int
 	for _, d := range diffs {


### PR DESCRIPTION
## What

Eliminate all surviving mutation-testing mutants in `pkg/diffyml/comparator.go` — 44 LIVED at the start, 0 now.

## Why

`comparator.go` had 44 surviving mutants. `make mutation`'s per-PR gate disallows LIVED mutants on changed lines, and the post-merge efficacy floor benefits from closing real test gaps.

## How

Two commits:

1. **`test:`** — 22 new black-box tests in `compare_test.go` targeting genuine test gaps: K8s detection short-circuit, both-null documents, asymmetric identifier matching, list-heterogeneity heuristics, unordered-walk skip/break edges, duplicate-identifier order detection, the mixed-identifier fallback path, `couldBeJSON` edges, and `deepEqualOrderedMaps` size guard. This brought survivors 44 → 17.

2. **`refactor:`** — the remaining 17 were equivalent mutants: guards that are dead or redundant under the public `Compare` API. `Compare` normalizes `nil` opts to `&Options{}` before any internal call, so the `opts != nil` checks in `compareDocs`/`compareNodes`/`compareLists`/`compareListsByIdentifier` were unreachable. `compareNodeNils`' `to == nil` branch produced the same `DiffModified` as the type-switch fallthrough; `deepEqual`'s nil short-circuits are covered by the `default` branch's `equalValues`. Also dropped the empty-`allKeys` and `<2`-common-order guards (downstream already returns false/nil) and replaced the `break`-after-set order walk with `slices.EqualFunc`. Internal tests that passed `nil` opts now pass `&Options{}`.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

The local gomutants binary is a `v0.2.3` dev build whose viability detection differs from the project-pinned `v0.2.2`; the 0-LIVED result was confirmed with it, but CI's `v0.2.2` is the source of truth. The `refactor:` commit changes production behavior only by removing provably-dead branches — all existing tests pass unchanged (aside from the `nil` → `&Options{}` opts in internal white-box tests).