### PR TITLE
chore: bump gomutants v0.2.2 -> v0.2.3

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -62,9 +62,9 @@ jobs:
       # "no LIVED mutant in the diff" via threshold-efficacy=100.
       - name: Run mutation testing (PR — diff only)
         if: github.event_name == 'pull_request'
-        uses: szhekpisov/gomutants@4281ef616b679c0b19d5ff39d8b673bb13ec0548 # v0.2.2
+        uses: szhekpisov/gomutants@564651b902e1c9a9bf5da154126532e276e4cee5 # v0.2.3
         with:
-          version: v0.2.2
+          version: v0.2.3
           threshold-efficacy: "100"
           args: >-
             --workers 2
@@ -81,9 +81,9 @@ jobs:
       # legacy 100% figure. Ratchet up as tests improve.
       - name: Run mutation testing (post-merge — full)
         if: github.event_name == 'push'
-        uses: szhekpisov/gomutants@4281ef616b679c0b19d5ff39d8b673bb13ec0548 # v0.2.2
+        uses: szhekpisov/gomutants@564651b902e1c9a9bf5da154126532e276e4cee5 # v0.2.3
         with:
-          version: v0.2.2
+          version: v0.2.3
           threshold-efficacy: "85.65"
           args: >-
             --workers 2

--- a/doc/mutation-testing.md
+++ b/doc/mutation-testing.md
@@ -16,7 +16,7 @@ A surviving mutant means either the test suite has a gap, or the mutation is **e
 
 ## Tool
 
-[gomutants](https://github.com/szhekpisov/gomutants) v0.2.1
+[gomutants](https://github.com/szhekpisov/gomutants) v0.2.3
 
 ## CI Integration
 


### PR DESCRIPTION
## What

Bump the gomutants mutation-testing tool from v0.2.2 to v0.2.3.

## Why

Keep the mutation-testing CI pinned to the latest gomutants release.

## How

- `.github/workflows/mutation.yml`: update both `uses:` SHA pins to `564651b902e1c9a9bf5da154126532e276e4cee5` (v0.2.3) and both `version:` inputs to `v0.2.3`.
- `doc/mutation-testing.md`: update the tool reference (was still showing the stale `v0.2.1`).

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [ ] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

CI-config-only change; no source code touched.