### PR TITLE
chore: scope GHA permissions per SonarCloud, reorder badges

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,5 @@
 name: PR Title
 
-permissions: read-all
-
 on:
   pull_request:
     types: [opened, edited, synchronize]
@@ -9,6 +7,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check PR title convention
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,11 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: read
-
 jobs:
   verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Validate semver tag
         run: |

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,8 +6,6 @@ on:
   schedule:
     - cron: '30 1 * * 6'
 
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis
@@ -15,6 +13,10 @@ jobs:
     permissions:
       security-events: write
       id-token: write
+      contents: read
+      actions: read
+      checks: read
+      pull-requests: read
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A fast, structural YAML diff tool with built-in Kubernetes intelligence. One dep
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/szhekpisov/diffyml/badge)](https://scorecard.dev/viewer/?uri=github.com/szhekpisov/diffyml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/szhekpisov/diffyml)](https://goreportcard.com/report/github.com/szhekpisov/diffyml)
-[![Go Reference](https://pkg.go.dev/badge/github.com/szhekpisov/diffyml.svg)](https://pkg.go.dev/github.com/szhekpisov/diffyml)
 [![codecov](https://codecov.io/gh/szhekpisov/diffyml/branch/main/graph/badge.svg)](https://codecov.io/gh/szhekpisov/diffyml)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fszhekpisov%2Fdiffyml%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/szhekpisov/diffyml/main)
 [![Release](https://img.shields.io/github/v/release/szhekpisov/diffyml)](https://github.com/szhekpisov/diffyml/releases/latest)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml?ref=badge_shield&issueType=security)
+[![Go Reference](https://pkg.go.dev/badge/github.com/szhekpisov/diffyml.svg)](https://pkg.go.dev/github.com/szhekpisov/diffyml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 <img src="doc/demo.png" alt="diffyml output" width="800">
 


### PR DESCRIPTION
## What

Tighten GitHub Actions permissions flagged by SonarCloud and reorder README badges.

## Why

SonarCloud raised three `githubactions:S8234`/`S8264` MAJOR issues on the workflows:

- `release.yml:9` — workflow-level `contents: read` should be scoped to the job that needs it.
- `pr-title.yml:3` — `permissions: read-all` is too broad.
- `scorecard.yml:9` — `permissions: read-all` is too broad.

Badge reorder is cosmetic.

## How

- `release.yml`: dropped the workflow-level `permissions` block; added `contents: read` to the `verify` job (other jobs already declare explicit permissions).
- `pr-title.yml`: removed `permissions: read-all`; added job-level `contents: read` (the workflow only reads `github.event.pull_request.title`).
- `scorecard.yml`: removed `permissions: read-all`; expanded the single job's permission block to the explicit list ossf/scorecard-action's README recommends (`contents/actions/checks/pull-requests: read`) alongside the existing `security-events: write` and `id-token: write`.
- `README.md`: moved Go Reference and License badges to the end of the badge list.

## Checklist

- [x] PR title follows convention (`chore:`)
- [x] `make ci` passes locally (workflow + README changes only — no Go code touched)
- [x] New/changed behavior covered by tests (N/A — CI config + docs)
- [x] Coverage thresholds met (N/A)
- [x] No new dependencies

## Notes for reviewers

Scorecard's own README documents `read-all` as one acceptable option, so this is intentionally swapping to the explicit-permissions alternative they also document — no functional change to what Scorecard can do.