### PR TITLE
doc: add SonarCloud Quality Gate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A fast, structural YAML diff tool with built-in Kubernetes intelligence. One dep
 [![codecov](https://codecov.io/gh/szhekpisov/diffyml/branch/main/graph/badge.svg)](https://codecov.io/gh/szhekpisov/diffyml)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fszhekpisov%2Fdiffyml%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/szhekpisov/diffyml/main)
 [![Release](https://img.shields.io/github/v/release/szhekpisov/diffyml)](https://github.com/szhekpisov/diffyml/releases/latest)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=szhekpisov_diffyml&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=szhekpisov_diffyml)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml.svg?type=shield&issueType=security)](https://app.fossa.com/projects/git%2Bgithub.com%2Fszhekpisov%2Fdiffyml?ref=badge_shield&issueType=security)
 [![Go Reference](https://pkg.go.dev/badge/github.com/szhekpisov/diffyml.svg)](https://pkg.go.dev/github.com/szhekpisov/diffyml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## What

Add the SonarCloud Quality Gate badge to the README.

## Why

The SonarCloud workflow is already wired up (see #155), but the gate status wasn't surfaced in the README. Adding the badge lets contributors and users see the current quality gate status at a glance alongside coverage, mutation testing, and release badges.

## How

Insert the standard SonarCloud `alert_status` shield in the README badge block, placed next to the other quality/coverage badges and linking to the project's SonarCloud summary view.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] \`make ci\` passes locally (docs-only change)
- [x] New/changed behavior covered by tests (N/A — README only)
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

Docs-only change. Verify the badge renders and the link resolves to the SonarCloud project summary.