### PR TITLE
chore: bump gomutants v0.2.3 -> v0.3.0

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -62,9 +62,9 @@ jobs:
       # "no LIVED mutant in the diff" via threshold-efficacy=100.
       - name: Run mutation testing (PR — diff only)
         if: github.event_name == 'pull_request'
-        uses: szhekpisov/gomutants@564651b902e1c9a9bf5da154126532e276e4cee5 # v0.2.3
+        uses: szhekpisov/gomutants@66cfd6c00236cf3e9fc5aca500370237c7abecd8 # v0.3.0
         with:
-          version: v0.2.3
+          version: v0.3.0
           threshold-efficacy: "100"
           args: >-
             --workers 2
@@ -81,9 +81,9 @@ jobs:
       # legacy 100% figure. Ratchet up as tests improve.
       - name: Run mutation testing (post-merge — full)
         if: github.event_name == 'push'
-        uses: szhekpisov/gomutants@564651b902e1c9a9bf5da154126532e276e4cee5 # v0.2.3
+        uses: szhekpisov/gomutants@66cfd6c00236cf3e9fc5aca500370237c7abecd8 # v0.3.0
         with:
-          version: v0.2.3
+          version: v0.3.0
           threshold-efficacy: "85.65"
           args: >-
             --workers 2

--- a/doc/mutation-testing.md
+++ b/doc/mutation-testing.md
@@ -16,7 +16,7 @@ A surviving mutant means either the test suite has a gap, or the mutation is **e
 
 ## Tool
 
-[gomutants](https://github.com/szhekpisov/gomutants) v0.2.3
+[gomutants](https://github.com/szhekpisov/gomutants) v0.3.0
 
 ## CI Integration
 


### PR DESCRIPTION
## What

Bump the gomutants mutation-testing action from v0.2.3 to v0.3.0.

## Why

Keep the mutation-testing toolchain current.

## How

Updated all five references:
- `.github/workflows/mutation.yml` — pinned action SHA + comment and `version:` input for both the PR (diff-only) and post-merge (full) jobs.
- `doc/mutation-testing.md` — version reference in prose.

Pinned to commit `66cfd6c00236cf3e9fc5aca500370237c7abecd8` (tag v0.3.0).

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [ ] `make ci` passes locally
- [ ] New/changed behavior covered by tests
- [ ] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

The post-merge `threshold-efficacy: "85.65"` floor was measured against an older gomutants. If v0.3.0 changes mutator behavior, this floor may need revisiting.