### PR TITLE
chore: bump Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/_docs-build.yml
+++ b/.github/workflows/_docs-build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Install Hugo extended
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Run benchmarks
         run: go test -bench=. -benchmem -count=1 -benchtime=100ms -timeout=5m ./pkg/diffyml/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
 
       - name: Run tests
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
 
       - name: Install cosign

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -81,6 +81,6 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Run tests
         run: go test -race ./...
@@ -81,7 +81,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Run fuzz tests
         run: |
@@ -101,7 +101,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Run tests with coverage
         run: go test ./pkg/diffyml/ -coverprofile=coverage.out
@@ -162,7 +162,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
           cache: false
 
       - name: Install goreleaser

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Contributions welcome! [Open an issue](https://github.com/szhekpisov/diffyml/iss
 <details>
 <summary>Development setup</summary>
 
-**Prerequisites:** Go 1.26.3+, [pre-commit](https://pre-commit.com/)
+**Prerequisites:** Go 1.26.4+, [pre-commit](https://pre-commit.com/)
 
 ```bash
 git clone https://github.com/szhekpisov/diffyml.git

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -102,7 +102,7 @@ cd diffyml
 go build -o diffyml
 ```
 
-Requires Go 1.26.3 or later.
+Requires Go 1.26.4 or later.
 
 ## Verifying releases
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/szhekpisov/diffyml
 
-go 1.26.3
+go 1.26.4
 
 require go.yaml.in/yaml/v3 v3.0.4


### PR DESCRIPTION
## What

Bump the Go toolchain from 1.26.3 to 1.26.4.

## Why

govulncheck flags two Go 1.26.3 standard-library advisories, both fixed in 1.26.4:

- **GO-2026-5039** — `net/textproto`: arbitrary inputs included in errors without escaping (reachable via `cli.Summarizer.Summarize` → `json.Decoder.Decode` → `textproto.Reader.ReadMIMEHeader`)
- **GO-2026-5037** — `crypto/x509`: inefficient candidate hostname parsing (reachable via certificate verification in `cli.Run`)

## How

`1.26.3` → `1.26.4` across:

- `go.mod` `go` directive
- `go-version` pins in 5 CI workflows (`release`, `_docs-build`, `security`, `test`, `benchmark`)
- documented prerequisite in `README.md` and `docs/content/docs/install.md`

Verified locally with the 1.26.4 toolchain: `go build ./...`, `go vet ./...`, and the full `go test ./...` suite all pass, and `govulncheck ./...` now reports **No vulnerabilities found**.

## Checklist

- [x] PR title follows convention (`chore:`)
- [x] `make ci` passes locally (security stage now clean under 1.26.4)
- [x] New/changed behavior covered by tests (no behavior change; existing suite passes)
- [x] Coverage thresholds met (unchanged)
- [x] No new dependencies

## Notes for reviewers

Toolchain/version-pin bump only — no production code changes. `doc/PERFORMANCE.md` (1.26.2) and `CLAUDE.md` are intentionally left untouched, as they record a historical benchmark environment / project instructions rather than the build requirement.
