### PR TITLE
feat: add Windows build targets to goreleaser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,38 @@ jobs:
       - name: Run tests
         run: go test -race ./...
 
+  windows-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: windows-latest
+    env:
+      CGO_ENABLED: "0"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.26.4"
+
+      - name: Run tests
+        run: go test ./... # no -race: requires a C toolchain on Windows; logic-level race coverage runs on the ubuntu test job
+
+      - name: Smoke test binary
+        shell: pwsh
+        run: |
+          go build -o diffyml.exe .
+          ./diffyml.exe --version
+          "name: test`nvalue: 1" | Set-Content a.yaml
+          "name: test`nvalue: 2" | Set-Content b.yaml
+          ./diffyml.exe -s a.yaml b.yaml
+          if ($LASTEXITCODE -ne 1) { Write-Error "expected exit 1 for differing files, got $LASTEXITCODE"; exit 1 }
+          ./diffyml.exe -s a.yaml a.yaml
+          if ($LASTEXITCODE -ne 0) { Write-Error "expected exit 0 for identical files, got $LASTEXITCODE"; exit 1 }
+          Write-Host "Windows smoke test passed"
+          exit 0
+
   fuzz:
     needs: changes
     if: needs.changes.outputs.code == 'true'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
@@ -21,6 +22,9 @@ builds:
 archives:
   - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
 nfpms:
   - id: packages

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The binary is installed to `/usr/bin/diffyml`.
 
 ### Direct binary download
 
-If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64):
+If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux, macOS, and Windows (amd64 and arm64). Linux/macOS ship as `.tar.gz`, Windows as `.zip`:
 
 ```bash
 VERSION=1.6.1  # check the releases page for the latest
@@ -153,6 +153,16 @@ ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 curl -fL "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/diffyml_${VERSION}_${OS}_${ARCH}.tar.gz" \
   | tar -xz
 sudo mv diffyml /usr/local/bin/
+```
+
+On Windows (PowerShell):
+
+```powershell
+$Version = "1.6.1"  # check the releases page for the latest
+$Arch = if ($Env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+curl.exe -fLO "https://github.com/szhekpisov/diffyml/releases/download/v$Version/diffyml_${Version}_windows_$Arch.zip"
+Expand-Archive "diffyml_${Version}_windows_$Arch.zip" -DestinationPath .
+# move diffyml.exe somewhere on your PATH
 ```
 
 See [Verifying Releases](#verifying-releases) below to check signatures and provenance before installing.

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -81,7 +81,7 @@ sudo apk add --allow-untrusted diffyml_1.6.1_linux_amd64.apk
 
 ## Direct binary download
 
-If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux and macOS (amd64 and arm64). Download, extract, and move onto your `PATH`:
+If you'd rather not pipe a script to `sh`, the same archives are attached to every [release](https://github.com/szhekpisov/diffyml/releases) for Linux, macOS, and Windows (amd64 and arm64). Linux/macOS ship as `.tar.gz`, Windows as `.zip`. Download, extract, and move onto your `PATH`:
 
 ```bash
 VERSION=1.6.1  # check the releases page for the latest
@@ -92,7 +92,17 @@ curl -fL "https://github.com/szhekpisov/diffyml/releases/download/v${VERSION}/di
 sudo mv diffyml /usr/local/bin/
 ```
 
-Archives are named `diffyml_<VERSION>_<os>_<arch>.tar.gz`. See [Verifying releases](#verifying-releases) to check signatures and provenance before installing.
+On Windows (PowerShell):
+
+```powershell
+$Version = "1.6.1"  # check the releases page for the latest
+$Arch = if ($Env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "amd64" }
+curl.exe -fLO "https://github.com/szhekpisov/diffyml/releases/download/v$Version/diffyml_${Version}_windows_$Arch.zip"
+Expand-Archive "diffyml_${Version}_windows_$Arch.zip" -DestinationPath .
+# move diffyml.exe somewhere on your PATH
+```
+
+Archives are named `diffyml_<VERSION>_<os>_<arch>.tar.gz` (`.zip` on Windows). See [Verifying releases](#verifying-releases) to check signatures and provenance before installing.
 
 ## From source
 


### PR DESCRIPTION
## What

Add `windows` (amd64 + arm64) build targets to GoReleaser, shipping Windows binaries as `.zip` archives, with docs and a Windows CI smoke test. Fixes #180.

## Why

The release config built only `darwin` and `linux`. Windows binaries make diffyml available to native Windows CI runners, Azure DevOps, and WSL users. The codebase is already Windows-clean: the only platform detection is `os.ModeCharDevice` in `pkg/diffyml/color.go`; no `syscall`, `exec.Command`, or `"path"` usage.

## How

- **`.goreleaser.yaml`:** added `windows` to `goos`; used a single `archives` entry with `format_overrides` to emit `.zip` for Windows while keeping `.tar.gz` for Unix.
  - Chose `format_overrides` over a second `archives` entry (as sketched in the issue) — a second entry leaves the default archive un-filtered, producing a stray Windows `.tar.gz` alongside the `.zip`. The override is the simpler, correct idiom and matches GoReleaser's documented pattern. Windows `.zip`-only also matches what `gh`, Helm, Hugo, golangci-lint, etc. ship.
  - Downstream blocks need no changes: `checksum`/`sboms`/`signs` pick up the zips automatically; `nfpms` stays linux-only; `dockers` and `brews` are unaffected.
- **Docs:** documented the Windows direct-download path (PowerShell `.zip` example) in both `README.md` and the docs-site mirror `docs/content/docs/install.md`.
- **`.github/workflows/test.yml`:** added a `windows-test` job (runs on `windows-latest`, gated on the existing `code` filter) that runs the full test suite on Windows and smoke-tests the built `diffyml.exe` (`--version`, and `-s` exit codes for differing vs. identical files). This is the real-OS analog of the existing Linux package-verify job and catches `path/filepath`, terminal-detection, and CRLF regressions that cross-compiling alone can't.

Verified locally: `goreleaser check` passes; `GOOS=windows` cross-compiles for amd64/arm64; a `--snapshot` build produces `diffyml_*_windows_{amd64,arm64}.zip` each containing `diffyml.exe`, no stray Windows `.tar.gz`, linux-only `.deb`/`.rpm`/`.apk`, and the zips listed in `checksums.txt`. Workflow validated with `actionlint`.

## Checklist

- [x] PR title follows convention (`feat:`)
- [ ] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

- No Go source changed; this is release-config + docs + a CI job. `make ci` unchecked for that reason (the build matrix is exercised at release time, validated here via `goreleaser` snapshot).
- The new `windows-test` job gates on the `code` filter, so it does **not** run on this PR (no `.go` files changed) — it debuts on the next Go-code PR. Let me know if you'd prefer the `code` filter to also include `.github/workflows/test.yml` so the matrix runs when the workflow itself changes.
- Scoop/winget manifests remain follow-up work per the issue.