### PR TITLE
feat: publish Scoop manifest for Windows installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
 
       - name: Generate subject hashes for SLSA provenance
         id: hash

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -155,6 +155,21 @@ brews:
       output = shell_output("#{bin}/diffyml #{testpath}/file1.yaml #{testpath}/file2.yaml")
       assert_match "value", output
 
+scoops:
+  - repository:
+      owner: szhekpisov
+      name: scoop-diffyml
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    commit_author:
+      name: github-actions[bot]
+      email: github-actions[bot]@users.noreply.github.com
+    directory: bucket
+    homepage: "https://github.com/szhekpisov/diffyml"
+    description: "Structural diff tool for YAML files"
+    license: "MIT"
+    skip_upload: auto
+    commit_msg_template: "Update diffyml to {{ .Version }}"
+
 changelog:
   sort: asc
   groups:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ diffyml compares YAML files and shows meaningful, structured differences — not
 - [How It Compares](#how-it-compares)
 - [Installation](#installation)
   - [Homebrew](#homebrew)
+  - [Scoop (Windows)](#scoop-windows)
   - [Go Install](#go-install)
   - [Install script (Linux / macOS)](#install-script-linux--macos)
   - [Linux packages (`.deb` / `.rpm` / `.apk`)](#linux-packages-deb--rpm--apk)
@@ -87,6 +88,13 @@ Comparison based on dyff v1.11.3 and diffyml v1.5.23. See [PERFORMANCE.md](doc/P
 ```bash
 brew tap szhekpisov/diffyml
 brew install diffyml
+```
+
+### Scoop (Windows)
+
+```powershell
+scoop bucket add diffyml https://github.com/szhekpisov/scoop-diffyml
+scoop install diffyml
 ```
 
 ### Go Install

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -12,6 +12,13 @@ brew tap szhekpisov/diffyml
 brew install diffyml
 ```
 
+## Scoop (Windows)
+
+```powershell
+scoop bucket add diffyml https://github.com/szhekpisov/scoop-diffyml
+scoop install diffyml
+```
+
 ## Go install
 
 ```bash


### PR DESCRIPTION
## What

Publish a [Scoop](https://scoop.sh) manifest so Windows users can install diffyml via `scoop install diffyml`. Builds on the Windows `.zip` archives added in v1.7.0 (#180).

## Why

v1.7.0 shipped Windows binaries but offered no package-manager install path — only manual `.zip` download. Scoop is the de-facto Windows analog of Homebrew, so this gives Windows users a first-class install/update experience matching the existing `brew install diffyml`.

## How

- **`.goreleaser.yaml`:** added a `scoops:` block mirroring the existing `brews:` tap — same `commit_author`, `skip_upload: auto`, and metadata conventions. It consumes the Windows `.zip` archives already produced by the `archives` + `format_overrides` config and commits the generated manifest to the `szhekpisov/scoop-diffyml` bucket repo (`directory: bucket`).
- **`.github/workflows/release.yml`:** passed `SCOOP_BUCKET_TOKEN` to the GoReleaser step env, alongside `HOMEBREW_TAP_TOKEN`.
- **Docs:** added a `Scoop (Windows)` install section to `README.md` (+ TOC entry) and the docs-site mirror `docs/content/docs/install.md`.

The bucket repo (`scoop-diffyml`) already exists with its own README; GoReleaser populates `bucket/diffyml.json` automatically on each release — no hand-authored manifest.

Verified locally: `goreleaser check` passes; `actionlint` and `zizmor` (offline, default ruleset) are clean on the workflows; a `--snapshot` build generates `dist/scoop/bucket/diffyml.json` with correct `64bit` + `arm64` entries, each pointing at the right `..._windows_<arch>.zip` with `bin: diffyml.exe` and a matching hash.

## Checklist

- [x] PR title follows convention (`feat:`)
- [ ] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

- No Go source changed; release-config + docs only. `make ci` unchecked for that reason (the manifest is exercised at release time, validated here via `goreleaser` snapshot + `goreleaser check`).
- **Merge prerequisite for the next release:** a `SCOOP_BUCKET_TOKEN` secret (PAT with write access to `scoop-diffyml`) must be added to this repo before the next `v*` tag, or the release's GoReleaser step will fail when pushing the manifest. The config is inert until then, so this PR is safe to merge first.
- The bucket is populated by the first release built with this config, so `scoop install diffyml` works from that release onward (not retroactively for v1.7.0).