### PR TITLE
ci: don't cancel post-merge mutation runs

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -3,9 +3,12 @@ name: Mutation Testing
 permissions:
   contents: read
 
+# Only cancel superseded PR runs (fast, --changed-since). Post-merge runs on
+# main are full-tree (~95 min) and must run to completion — cancelling them
+# leaves gomutants gating on a partial, misleadingly-low efficacy number.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:


### PR DESCRIPTION
## What

Stop cancelling the post-merge (push-to-`main`) mutation run, so it can finish.

## Why

The recent `Mutation Testing` failures on `main` are **not** an efficacy regression — they are aborted runs. The full-tree post-merge run takes ~95 min (3278 mutants × 2 workers), but `concurrency.cancel-in-progress: true` on a per-ref group cancels it whenever the next push to `main` lands. gomutants then flushes a **partial** summary and the gate fails on it:

| Run | Mutants scored | Reported efficacy | Ended by |
|---|---|---|---|
| Jun 25 | ~656 / 3278 | 72.74% | `runner received a shutdown signal` |
| Jun 21 | ~718 / 3278 | 75.11% | `operation was canceled` |

The last *complete* run (Jun 15) passed at ≥85%, so the `threshold-efficacy: 85.0` floor is still valid — the runs just never finish.

## How

Restrict `cancel-in-progress` to pull-request events:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR runs (fast, `--changed-since`) still supersede each other; post-merge full-tree runs on `main` run to completion.

## Checklist

- [x] PR title follows convention (`ci:`)
- [ ] `make ci` passes locally (no code change; workflow-only)
- [x] No new dependencies

## Notes for reviewers

- Workflow-only change. Follow-ups we discussed but intentionally left out of this PR: bumping `--workers` and adding `actions/cache` for `.gomutants-cache.json` to make the full run faster/incremental.
