### PR TITLE
fix: apply path filters across documents in multi-doc YAML

### DIFF
--- a/pkg/diffyml/filter.go
+++ b/pkg/diffyml/filter.go
@@ -141,6 +141,14 @@ func matchesAnyRegexWithNested(diffPath string, nestedPaths []string, patterns [
 // included/excluded. This is intentional — list item diffs are atomic,
 // so partial filtering would not be meaningful.
 func nestedKeyPaths(diff Difference) []string {
+	return nestedKeyPathsFrom(diff.Path, diff)
+}
+
+// nestedKeyPathsFrom behaves like nestedKeyPaths but appends the diff's
+// added/removed map keys to an explicit base path rather than diff.Path. This
+// lets callers build nested key paths for a document-index-stripped base so
+// document-index-agnostic filters can match multi-document diffs.
+func nestedKeyPathsFrom(base DiffPath, diff Difference) []string {
 	var om *OrderedMap
 	switch diff.Type {
 	case DiffRemoved:
@@ -157,7 +165,7 @@ func nestedKeyPaths(diff Difference) []string {
 	}
 	paths := make([]string, len(om.Keys))
 	for i, key := range om.Keys {
-		paths[i] = diff.Path.Append(key).String()
+		paths[i] = base.Append(key).String()
 	}
 	return paths
 }
@@ -213,6 +221,14 @@ func FilterDiffsWithRegexpReport(diffs []Difference, opts *FilterOptions, report
 	for _, diff := range diffs {
 		pathStr := diff.Path.String()
 		nested := nestedKeyPaths(diff)
+		// Document-index-agnostic filters (e.g. metadata.annotations) should match
+		// multi-document diffs whose paths are prefixed with [N]. Add the stripped
+		// path and its nested keys as additional match candidates. The raw pathStr
+		// is retained so document-scoped filters ([0].metadata) still work.
+		if _, rest, ok := diff.Path.DocIndexPrefix(); ok {
+			nested = append(nested, rest.String())
+			nested = append(nested, nestedKeyPathsFrom(rest, diff)...)
+		}
 		included := true
 
 		// Step 1: Apply include filters (path or regex)

--- a/pkg/diffyml/filter_test.go
+++ b/pkg/diffyml/filter_test.go
@@ -966,3 +966,107 @@ func TestFilterDiffsWithRegexpReport_PathExclusionNotCounted(t *testing.T) {
 		}
 	}
 }
+
+// multiDocMetadataDiffs mimics the diff shape produced for multi-document YAML:
+// every path carries a leading document-index segment like [0]. Used by the
+// document-index-prefix filter tests below (issue #189).
+func multiDocMetadataDiffs() []Difference {
+	return []Difference{
+		{Path: DiffPath{"[0]", "metadata", "annotations"}, Type: DiffRemoved, From: "a", To: nil},
+		{Path: DiffPath{"[0]", "metadata", "labels"}, Type: DiffRemoved, From: "l", To: nil},
+		{Path: DiffPath{"[1]", "metadata", "annotations"}, Type: DiffRemoved, From: "a", To: nil},
+		{Path: DiffPath{"[2]", "metadata", "annotations"}, Type: DiffRemoved, From: "a", To: nil},
+	}
+}
+
+func TestFilterDiffs_ExcludePaths_DocIndexAgnosticAcrossDocs(t *testing.T) {
+	// A bare filter path must match the same field in every document.
+	opts := &FilterOptions{ExcludePaths: []string{"metadata.annotations"}}
+
+	result := FilterDiffs(multiDocMetadataDiffs(), opts)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 diff after excluding metadata.annotations across all docs, got %d", len(result))
+	}
+	if result[0].Path.String() != "[0].metadata.labels" {
+		t.Errorf("expected [0].metadata.labels to survive, got %s", result[0].Path)
+	}
+}
+
+func TestFilterDiffs_IncludePaths_DocIndexAgnosticAcrossDocs(t *testing.T) {
+	opts := &FilterOptions{IncludePaths: []string{"metadata.annotations"}}
+
+	result := FilterDiffs(multiDocMetadataDiffs(), opts)
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 annotations diffs across docs, got %d", len(result))
+	}
+	for _, d := range result {
+		if d.Path.Last() != "annotations" {
+			t.Errorf("unexpected diff included: %s", d.Path)
+		}
+	}
+}
+
+func TestFilterDiffs_ExcludePaths_DocScopedFilterKeepsOtherDocs(t *testing.T) {
+	// A document-scoped filter ([0].metadata) must affect only that document,
+	// proving the raw path is retained alongside the stripped candidate.
+	opts := &FilterOptions{ExcludePaths: []string{"[0].metadata"}}
+
+	result := FilterDiffs(multiDocMetadataDiffs(), opts)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 diffs (docs 1 and 2 untouched), got %d", len(result))
+	}
+	for _, d := range result {
+		if idx, _ := d.Path.DocIndex(); idx == 0 {
+			t.Errorf("doc 0 diff should have been excluded: %s", d.Path)
+		}
+	}
+}
+
+func TestFilterDiffs_ExcludePaths_BareDocIndexExcludesWholeDoc(t *testing.T) {
+	// A bare [2] filter excludes the whole document; DocIndexPrefix returns
+	// ok=false for the bare-index diff, so the raw [2] candidate is what matches.
+	diffs := append(
+		multiDocMetadataDiffs(),
+		Difference{Path: DiffPath{"[2]"}, Type: DiffRemoved, From: "doc", To: nil},
+	)
+
+	opts := &FilterOptions{ExcludePaths: []string{"[2]"}}
+
+	result := FilterDiffs(diffs, opts)
+
+	for _, d := range result {
+		if idx, _ := d.Path.DocIndex(); idx == 2 {
+			t.Errorf("all doc 2 diffs should be excluded, got %s", d.Path)
+		}
+	}
+	if len(result) != 3 {
+		t.Fatalf("expected 3 diffs (docs 0 and 1), got %d", len(result))
+	}
+}
+
+func TestFilterDiffs_ExcludePaths_DocIndexStrippedNestedKey(t *testing.T) {
+	// A removed map carried on a doc-index-prefixed path must be excludable by
+	// its bare nested key path (exercises nestedKeyPathsFrom on the stripped base).
+	diffs := []Difference{
+		{
+			Path: DiffPath{"[1]", "metadata"},
+			Type: DiffRemoved,
+			From: &OrderedMap{Keys: []string{"annotations"}, Values: map[string]any{"annotations": "x"}},
+		},
+		{Path: DiffPath{"[1]", "data", "key1"}, Type: DiffModified, From: "old", To: "new"},
+	}
+
+	opts := &FilterOptions{ExcludePaths: []string{"metadata.annotations"}}
+
+	result := FilterDiffs(diffs, opts)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 diff after excluding nested key across docs, got %d", len(result))
+	}
+	if result[0].Path.String() != "[1].data.key1" {
+		t.Errorf("expected [1].data.key1 to survive, got %s", result[0].Path)
+	}
+}


### PR DESCRIPTION
## What

Make `--exclude` / `--include` path filters (and `--neat`) work on multi-document YAML. Part of #189 — this PR fixes the document-index-prefix half only; a follow-up PR will address filtering keys nested inside a bulk-removed sub-map, so this PR intentionally does **not** close the issue.

## Why

For multi-document input, every diff's path is prefixed with a document-index segment like `[0]` (e.g. `[0].metadata.annotations`). The path filter matched the raw string, and `pathMatches` only does exact- or filter-is-a-prefix matching, so a user filter `metadata.annotations` was never a prefix of `[0].metadata.annotations` → all `--exclude`/`--include` filters silently no-op'd on multi-doc YAML. `--neat` inherits the same blind spot (its `^metadata\.…` regexes are fed into `ExcludeRegexp`).

## How

When a diff path carries a leading `[N]` segment, add the document-index-stripped path **and** its nested map keys as additional match candidates, while retaining the raw path. This reuses the existing `DiffPath.DocIndexPrefix()` helper, mirroring how `mask.go` already handles the prefix.

Retaining the raw path keeps document-scoped filters working: `--exclude '[0].metadata'` still scopes to doc 0 and `--exclude '[0]'` still excludes a whole document. Single-document diffs have no `[N]` prefix, so their behavior is byte-for-byte unchanged.

- `nestedKeyPaths` split into `nestedKeyPathsFrom(base, diff)` so nested keys can be built against the stripped base.
- Bonus: `--neat` now strips noise (e.g. `metadata.creationTimestamp`) on multi-doc YAML, which previously leaked.

## Checklist

- [x] PR title follows convention (`fix:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (100% total)
- [x] No new dependencies

## Notes for reviewers

Scope is deliberately the document-index prefix only. The reporter's full command still yields three diffs, not the expected two, because `nestedKeyPaths` expands just one map level — so a filter targeting a key *inside* a bulk-removed sub-map (`metadata.labels.whatever`) still can't match. That's the tracked follow-up and is why this PR does not close #189.

Mutation gate on changed lines: 0 lived, 100% efficacy.
