### PR TITLE
doc: add inverse diff (--unchanged) to comparison tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ diffyml compares YAML files and shows meaningful, structured differences — not
 | CI annotation formats | 3 (GitHub, GitLab, Gitea) | 0 | 0 |
 | Module dependencies | 1 (yaml.v3) | 23 | 0 |
 | Directory comparison | Yes | No | Yes |
+| Inverse diff (report unchanged values) | Yes (`--unchanged`) | No | No |
 | Git external diff (`GIT_EXTERNAL_DIFF`) | Yes (auto-detect) | Manual (wrapper script) | N/A |
 | Inline diff highlighting | Yes (word-level) | Yes (character-level) | No |
 | Custom colors | Yes (hex, env vars) | No | No |

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -38,6 +38,7 @@ diffyml old.yaml new.yaml
 | Kubernetes resource matching | apiVersion + kind + name (or generateName) | apiVersion + kind + name | No |
 | Rename detection | Yes (content similarity) | Yes (identifier) | No |
 | API version migration | Yes (`--ignore-api-version`) | No | No |
+| Inverse diff (report unchanged values) | Yes (`--unchanged`) | No | No |
 | CI annotation formats | 3 (GitHub, GitLab, Gitea) | 0 | 0 |
 | Module dependencies | 1 (yaml.v3) | 23 | 0 |
 | Performance (78 KB) | 19 ms | 120 ms (6.4×) | 6 ms |


### PR DESCRIPTION
## What

Adds an **Inverse diff (report unchanged values)** row to the "How it compares" tables in both `README.md` and the docs site (`docs/content/_index.md`).

## Why

The `--unchanged` inverse diff mode was added in #184, but the comparison tables were never updated to surface it. Neither dyff nor plain `diff` offers this capability, so it's a diffyml-only differentiator worth listing.

## How

- `README.md` — new row after "Directory comparison".
- `docs/content/_index.md` — new row after "API version migration" (this table is a shorter variant without the directory-comparison row).