### PR TITLE
doc: document nixpkgs installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ diffyml compares YAML files and shows meaningful, structured differences — not
 - [Installation](#installation)
   - [Homebrew](#homebrew)
   - [Scoop (Windows)](#scoop-windows)
+  - [Nixpkgs](#nixpkgs)
   - [Go Install](#go-install)
   - [Install script (Linux / macOS)](#install-script-linux--macos)
   - [Linux packages (`.deb` / `.rpm` / `.apk`)](#linux-packages-deb--rpm--apk)
@@ -96,6 +97,33 @@ brew install diffyml
 ```powershell
 scoop bucket add diffyml https://github.com/szhekpisov/scoop-diffyml
 scoop install diffyml
+```
+
+### Nixpkgs
+
+Available in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/di/diffyml/package.nix) on the **unstable** channel. It landed after the 26.05 branch-off, so it isn't in the current stable release yet — it will be in the next one.
+
+```bash
+# Ephemeral shell
+nix shell nixpkgs#diffyml
+
+# Run without installing
+nix run nixpkgs#diffyml -- old.yaml new.yaml
+
+# Install into your profile
+nix profile install nixpkgs#diffyml
+```
+
+On NixOS, add it to `environment.systemPackages`:
+
+```nix
+environment.systemPackages = with pkgs; [ diffyml ];
+```
+
+Without flakes:
+
+```bash
+nix-env -iA nixpkgs.diffyml   # or: nix-shell -p diffyml
 ```
 
 ### Go Install

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -24,7 +24,7 @@ diffyml old.yaml new.yaml
 
 ## Where to next
 
-- **[Install]({{< relref "/docs/install" >}})** — Homebrew, Docker, `go install`, release binaries
+- **[Install]({{< relref "/docs/install" >}})** — Homebrew, Nix, Docker, `go install`, release binaries
 - **[Quick Start]({{< relref "/docs/quick-start" >}})** — three minimal examples that cover 90% of usage
 - **[Output Formats]({{< relref "/docs/formats" >}})** — pick the right format for terminal review or CI
 - **[CI Integration]({{< relref "/docs/ci" >}})** — GitHub Actions, GitLab Code Quality, Gitea, kubectl, git

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -19,6 +19,33 @@ scoop bucket add diffyml https://github.com/szhekpisov/scoop-diffyml
 scoop install diffyml
 ```
 
+## Nixpkgs
+
+Available in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/di/diffyml/package.nix) on the **unstable** channel. It landed after the 26.05 branch-off, so it isn't in the current stable release yet — it will be in the next one.
+
+```bash
+# Ephemeral shell
+nix shell nixpkgs#diffyml
+
+# Run without installing
+nix run nixpkgs#diffyml -- old.yaml new.yaml
+
+# Install into your profile
+nix profile install nixpkgs#diffyml
+```
+
+On NixOS, add it to `environment.systemPackages`:
+
+```nix
+environment.systemPackages = with pkgs; [ diffyml ];
+```
+
+Without flakes:
+
+```bash
+nix-env -iA nixpkgs.diffyml   # or: nix-shell -p diffyml
+```
+
 ## Go install
 
 ```bash


### PR DESCRIPTION
## Summary

diffyml was packaged into nixpkgs in [NixOS/nixpkgs#535583](https://github.com/NixOS/nixpkgs/pull/535583) ("diffyml: init at 1.7.0", merged 2026-07-11). This PR adds docs with Nix install path.

- `README.md` — new `### Nixpkgs` section after Scoop, plus the Table of Contents entry
- `docs/content/docs/install.md` — same section as `## Nixpkgs` (sentence-case `##` to match that page's convention)
- `docs/content/_index.md` — Nix added to the "Where to next" install summary

Covers flakes (`nix shell` / `nix run` / `nix profile install`), the NixOS `environment.systemPackages` snippet, and the non-flake `nix-env -iA` / `nix-shell -p` fallback.

## Unstable-channel caveat

The section states the package is on the **unstable** channel only. This is deliberate: the merge landed after the 26.05 branch-off, so the attribute is absent from `nixos-26.05` and `nixos-25.11`. Without the caveat, stable-channel users would hit a missing-attribute error and file it as a bug.

## No release-process change needed

The nixpkgs package uses `nix-update-script`, so it is bumped upstream from our release tags. Nothing to add to `.goreleaser.yaml` (nixpkgs isn't a goreleaser publish target), and no `doc/nixpkgs.md` maintainer guide paralleling `doc/homebrew.md` — there's nothing to maintain by hand.

Adding a `flake.nix` to this repo (which would enable `nix run github:szhekpisov/diffyml`) is a separate feature the nixpkgs merge doesn't provide, and is not included here.

## Verification

- `nix eval nixpkgs#diffyml.version` → `"1.7.0"` — the documented flake reference actually resolves
- Attribute name and channel presence checked directly against the nixpkgs repo: present in `nixos-unstable` and `nixpkgs-unstable`, absent from `nixos-25.11` and `nixos-26.05`
- `go test ./test/property/ -run 'TestProperty1[23]'` passes (these assert on README install headings)
- Hugo site builds clean with the pinned hugo-book v13 theme; the `#nixpkgs` anchor and its auto-generated page ToC entry both render

https://claude.ai/code/session_01MNvrpYzXnv4oy7trifwWuq