### PR TITLE
fix: help/version flag handling, and parallel directory comparison

### DIFF
--- a/doc/gen-cli-ref/main.go
+++ b/doc/gen-cli-ref/main.go
@@ -106,12 +106,13 @@ diffyml [flags] <from> <to>
 
 `
 
-const versionTrailer = `## Version
+// versionTrailer explains the one behavior the flag tables cannot: --help and
+// --version are ordinary flags (listed under "Other" above, so no table here
+// would repeat them) that short-circuit argument parsing.
+const versionTrailer = `## Help and version
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| ` + "`-V`, `--version`" + ` | ` + "`bool`" + ` | — | show version information |
-
-` + "`--version`" + ` is handled in ` + "`main.go`" + ` before flag parsing, so it works even
-when other arguments are missing or invalid.
+` + "`-h`/`--help`" + ` and ` + "`-V`/`--version`" + ` are parsed like any other flag, but they
+short-circuit before the ` + "`<from> <to>`" + ` arguments are required and before the
+config file is read — so they work with no arguments at all, and keep working
+when a config file is missing or malformed.
 `

--- a/docs/content/docs/ci.md
+++ b/docs/content/docs/ci.md
@@ -129,3 +129,18 @@ repos:
 ```
 
 Customize to taste — pre-commit hooks for diffing don't have a one-size-fits-all shape.
+
+## Parallelism and memory
+
+In directory mode, diffyml compares file pairs on one worker per usable CPU. `GOMAXPROCS` is container-aware, so the worker count already respects a runner's CPU quota — nothing needs configuring for the common case.
+
+Parallel comparison buffers every pair's differences so output can be replayed in file order, which makes peak memory grow with total diff volume rather than with the largest single pair. On 3000 differing manifests that is roughly 79 MB, against 18 MB when comparing sequentially, for about half the wall time.
+
+Container CPU limits are visible to diffyml; container *memory* limits are not. If a job is memory-capped rather than CPU-capped, trade the speed back with `--jobs`:
+
+```bash
+diffyml --jobs 1 manifests/old manifests/new   # sequential: one pair in memory at a time
+diffyml --jobs 4 manifests/old manifests/new   # cap CPU use at 4 workers
+```
+
+`--jobs 1` is the only setting that avoids the buffering, since results are only replayable in order if they are held. Any value of 2 or more caps CPU use but not peak memory. `--jobs 0` (the default) means one worker per CPU. Output is byte-identical at every setting.

--- a/docs/content/docs/config.md
+++ b/docs/content/docs/config.md
@@ -76,6 +76,9 @@ summary-model: "claude-haiku-4-5-20251001"
 
 # Exit code
 set-exit-code: false
+
+# Parallelism (directory mode only; 0 = one worker per CPU)
+jobs: 0
 ```
 
 See [Sensitive Value Masking]({{< relref "/docs/masking" >}}) for usage.

--- a/docs/content/docs/reference.md
+++ b/docs/content/docs/reference.md
@@ -94,6 +94,7 @@ diffyml [flags] <from> <to>
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--config` | `string` | `.diffyml.yml` | path to config file |
+| `--jobs` | `int` | `0` | file pairs compared in parallel in directory mode (0 = one per CPU, 1 = sequential, lowest memory) |
 
 ## Other
 

--- a/docs/content/docs/reference.md
+++ b/docs/content/docs/reference.md
@@ -104,11 +104,9 @@ diffyml [flags] <from> <to>
 | `-h`, `--help` | `bool` | — | show help |
 | `-V`, `--version` | `bool` | — | show version information |
 
-## Version
+## Help and version
 
-| Flag | Type | Default | Description |
-|------|------|---------|-------------|
-| `-V`, `--version` | `bool` | — | show version information |
-
-`--version` is handled in `main.go` before flag parsing, so it works even
-when other arguments are missing or invalid.
+`-h`/`--help` and `-V`/`--version` are parsed like any other flag, but they
+short-circuit before the `<from> <to>` arguments are required and before the
+config file is read — so they work with no arguments at all, and keep working
+when a config file is missing or malformed.

--- a/docs/content/docs/reference.md
+++ b/docs/content/docs/reference.md
@@ -101,6 +101,7 @@ diffyml [flags] <from> <to>
 |------|------|---------|-------------|
 | `-s`, `--set-exit-code` | `bool` | — | set program exit code based on differences |
 | `-h`, `--help` | `bool` | — | show help |
+| `-V`, `--version` | `bool` | — | show version information |
 
 ## Version
 

--- a/main.go
+++ b/main.go
@@ -39,8 +39,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return cli.ExitCodeSuccess
 	}
 
+	// Built from NewRunConfig rather than a bare literal so any future
+	// RunConfig default applies here too; only the writers are overridden.
+	rc := cli.NewRunConfig()
+	rc.Stdout = stdout
+	rc.Stderr = stderr
+
 	// cli.Run handles cfg.ShowHelp by writing usage to stdout.
-	result := cli.Run(cfg, &cli.RunConfig{Stdout: stdout, Stderr: stderr})
+	result := cli.Run(cfg, rc)
 	return result.Code
 }
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,10 @@ func run(args []string, stdout, stderr io.Writer) int {
 	cfg := cli.NewCLIConfig()
 
 	if err := cfg.ParseArgs(args); err != nil {
-		_, _ = io.WriteString(stderr, "Error: "+err.Error()+"\n")
+		// A bad flag no longer falls through to the help text the way the old
+		// os.Args pre-scan allowed, so point at it instead of leaving the user
+		// with only the error.
+		_, _ = io.WriteString(stderr, "Error: "+err.Error()+"\nRun 'diffyml --help' for usage.\n")
 		return cli.ExitCodeError
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 
 	"github.com/szhekpisov/diffyml/pkg/diffyml/cli"
@@ -18,30 +19,28 @@ func formatVersion() string {
 	return "diffyml version " + version + " (commit: " + commit + ", built: " + buildDate + ")\n"
 }
 
-func main() {
+// run parses args and executes the CLI, returning the process exit code.
+// Split from main so it is testable without os.Exit; stdout/stderr are
+// injected rather than referenced globally.
+func run(args []string, stdout, stderr io.Writer) int {
 	cfg := cli.NewCLIConfig()
 
-	// Check for version flag first
-	for _, arg := range os.Args[1:] {
-		if arg == "-V" || arg == "--version" || arg == "-version" {
-			_, _ = os.Stdout.WriteString(formatVersion())
-			os.Exit(0)
-		}
+	if err := cfg.ParseArgs(args); err != nil {
+		_, _ = io.WriteString(stderr, "Error: "+err.Error()+"\n")
+		return cli.ExitCodeError
 	}
 
-	// Check for help flag
-	for _, arg := range os.Args[1:] {
-		if arg == "-h" || arg == "--help" || arg == "-help" {
-			_, _ = os.Stdout.WriteString(cfg.Usage())
-			os.Exit(0)
-		}
+	// Version takes precedence over help, matching the previous ordering.
+	if cfg.ShowVersion {
+		_, _ = io.WriteString(stdout, formatVersion())
+		return cli.ExitCodeSuccess
 	}
 
-	if err := cfg.ParseArgs(os.Args[1:]); err != nil {
-		_, _ = os.Stderr.WriteString("Error: " + err.Error() + "\n")
-		os.Exit(cli.ExitCodeError)
-	}
+	// cli.Run handles cfg.ShowHelp by writing usage to stdout.
+	result := cli.Run(cfg, &cli.RunConfig{Stdout: stdout, Stderr: stderr})
+	return result.Code
+}
 
-	result := cli.Run(cfg, nil)
-	os.Exit(result.Code)
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -109,6 +109,47 @@ func TestVersionFlagWithLdflags(t *testing.T) {
 	}
 }
 
+// TestBadFlagReportsOnceWithHelpPointer covers the fallout of dropping the
+// os.Args pre-scan: "--typo --help" used to print usage and exit 0, because the
+// scan saw --help before anything was parsed. Parsing now happens first, so the
+// typo is reported instead. This runs as a subprocess because the flag package
+// writes its own error and usage dump to the FlagSet's output, which is the
+// process stderr rather than the writer run() is handed — an in-process test
+// capturing only run()'s stderr could not see the dump at all.
+func TestBadFlagReportsOnceWithHelpPointer(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), testBinaryName())
+	if out, err := exec.Command("go", "build", "-o", bin).CombinedOutput(); err != nil {
+		t.Fatalf("build test binary: %v\n%s", err, out)
+	}
+
+	for _, args := range [][]string{{"--typo"}, {"--typo", "--help"}} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			cmd := exec.Command(bin, args...)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected a non-zero exit for %v, got success:\n%s", args, out)
+			}
+			got := string(out)
+
+			// The flag package's own listing must not compete with Usage().
+			if strings.Contains(got, "Usage of diffyml:") {
+				t.Errorf("flag package usage dump leaked into output:\n%s", got)
+			}
+			// ...and the failure is reported exactly once, not echoed by both
+			// the flag package and main.
+			if n := strings.Count(got, "flag provided but not defined"); n != 1 {
+				t.Errorf("expected the error reported once, got %d times:\n%s", n, got)
+			}
+			if !strings.Contains(got, "Error: flag provided but not defined: -typo") {
+				t.Errorf("expected the curated error, got:\n%s", got)
+			}
+			if !strings.Contains(got, "Run 'diffyml --help' for usage.") {
+				t.Errorf("expected a pointer to --help, got:\n%s", got)
+			}
+		})
+	}
+}
+
 // TestFlagValuesNotMistakenForHelpOrVersion is a regression test: main used to
 // pre-scan os.Args for "-h"/"-V"/"--version", which also matched those strings
 // when they appeared as the *value* of a preceding flag. "--mask-placeholder -h"

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -105,6 +106,100 @@ func TestVersionFlagWithLdflags(t *testing.T) {
 		if !strings.Contains(outputStr, part) {
 			t.Errorf("Expected version output to contain '%s', got: %s", part, outputStr)
 		}
+	}
+}
+
+// TestFlagValuesNotMistakenForHelpOrVersion is a regression test: main used to
+// pre-scan os.Args for "-h"/"-V"/"--version", which also matched those strings
+// when they appeared as the *value* of a preceding flag. "--mask-placeholder -h"
+// printed usage instead of running the diff. Both are real flags now, so the
+// flag package binds the value to the flag that owns it.
+func TestFlagValuesNotMistakenForHelpOrVersion(t *testing.T) {
+	dir := t.TempDir()
+	from := filepath.Join(dir, "from.yaml")
+	to := filepath.Join(dir, "to.yaml")
+	if err := os.WriteFile(from, []byte("a: 1\n"), 0o600); err != nil {
+		t.Fatalf("write from: %v", err)
+	}
+	if err := os.WriteFile(to, []byte("a: 2\n"), 0o600); err != nil {
+		t.Fatalf("write to: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"placeholder is -h", []string{from, to, "--mask-placeholder", "-h"}},
+		{"placeholder is --help", []string{from, to, "--mask-placeholder", "--help"}},
+		{"summary-model is -V", []string{from, to, "--summary-model", "-V"}},
+		{"summary-model is --version", []string{from, to, "--summary-model", "--version"}},
+		{"filter is -h", []string{from, to, "--filter", "-h"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			code := run(tt.args, &stdout, &stderr)
+
+			if code != 0 {
+				t.Errorf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+			}
+			out := stdout.String()
+			if strings.Contains(out, "A diff tool for YAML files") {
+				t.Errorf("flag value was treated as --help; got usage output:\n%s", out)
+			}
+			if strings.Contains(out, "diffyml version") {
+				t.Errorf("flag value was treated as --version; got:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestHelpAndVersionWithoutFileArgs verifies --help and --version still work
+// with no file arguments, which is why the os.Args pre-scan existed. ParseArgs
+// now short-circuits before the "requires two file arguments" check instead.
+func TestHelpAndVersionWithoutFileArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"short help", []string{"-h"}, "A diff tool for YAML files"},
+		{"long help", []string{"--help"}, "A diff tool for YAML files"},
+		{"single-dash help", []string{"-help"}, "A diff tool for YAML files"},
+		{"short version", []string{"-V"}, "diffyml version"},
+		{"long version", []string{"--version"}, "diffyml version"},
+		{"single-dash version", []string{"-version"}, "diffyml version"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			code := run(tt.args, &stdout, &stderr)
+
+			if code != 0 {
+				t.Errorf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tt.want) {
+				t.Errorf("expected stdout to contain %q, got:\n%s", tt.want, stdout.String())
+			}
+		})
+	}
+}
+
+// TestVersionTakesPrecedenceOverHelp preserves the original ordering: main
+// checked the version flag before the help flag.
+func TestVersionTakesPrecedenceOverHelp(t *testing.T) {
+	var stdout, stderr strings.Builder
+	if code := run([]string{"--help", "--version"}, &stdout, &stderr); code != 0 {
+		t.Errorf("expected exit code 0, got %d (stderr: %s)", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "diffyml version") {
+		t.Errorf("expected version output, got:\n%s", out)
+	}
+	if strings.Contains(out, "A diff tool for YAML files") {
+		t.Errorf("expected version to win over help, got usage output:\n%s", out)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -19,18 +19,35 @@ func testBinaryName() string {
 	return name
 }
 
+// buildTestBinary builds diffyml for a subprocess test and returns its path.
+// ldflags, when given, is passed through to -ldflags.
+//
+// The binary goes under t.TempDir() and never the repository root. Building
+// into the root races with test/property, which asserts the root contains no
+// pre-built binaries: `go test ./...` runs packages concurrently, so a binary
+// living there even for the length of one test can fail that check.
+func buildTestBinary(t *testing.T, ldflags ...string) string {
+	t.Helper()
+
+	bin := filepath.Join(t.TempDir(), testBinaryName())
+	args := []string{"build"}
+	if len(ldflags) > 0 {
+		args = append(args, "-ldflags", strings.Join(ldflags, " "))
+	}
+	args = append(args, "-o", bin)
+
+	if out, err := exec.Command("go", args...).CombinedOutput(); err != nil {
+		t.Fatalf("Failed to build test binary: %v\n%s", err, out)
+	}
+	return bin
+}
+
 // TestVersionFlag tests that the --version flag displays version information
 func TestVersionFlag(t *testing.T) {
-	// Build the binary for testing
-	bin := testBinaryName()
-	cmd := exec.Command("go", "build", "-o", bin)
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to build test binary: %v", err)
-	}
-	defer os.Remove(bin)
+	bin := buildTestBinary(t)
 
 	// Test --version flag
-	cmd = exec.Command("./"+bin, "--version")
+	cmd := exec.Command(bin, "--version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to run --version: %v", err)
@@ -55,16 +72,10 @@ func TestVersionFlag(t *testing.T) {
 
 // TestVersionFlagShortForm tests that the -V flag displays version information
 func TestVersionFlagShortForm(t *testing.T) {
-	// Build the binary for testing
-	bin := testBinaryName()
-	cmd := exec.Command("go", "build", "-o", bin)
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to build test binary: %v", err)
-	}
-	defer os.Remove(bin)
+	bin := buildTestBinary(t)
 
 	// Test -V flag
-	cmd = exec.Command("./"+bin, "-V")
+	cmd := exec.Command(bin, "-V")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to run -V: %v", err)
@@ -79,17 +90,10 @@ func TestVersionFlagShortForm(t *testing.T) {
 // TestVersionFlagWithLdflags tests that version information can be injected via ldflags
 func TestVersionFlagWithLdflags(t *testing.T) {
 	// Build the binary with version injection
-	bin := testBinaryName()
-	cmd := exec.Command("go", "build",
-		"-ldflags", "-X main.version=1.2.3 -X main.commit=abc123def -X main.buildDate=2024-01-15",
-		"-o", bin)
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to build test binary with ldflags: %v", err)
-	}
-	defer os.Remove(bin)
+	bin := buildTestBinary(t, "-X main.version=1.2.3 -X main.commit=abc123def -X main.buildDate=2024-01-15")
 
 	// Test --version flag
-	cmd = exec.Command("./"+bin, "--version")
+	cmd := exec.Command(bin, "--version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("Failed to run --version: %v", err)
@@ -117,10 +121,7 @@ func TestVersionFlagWithLdflags(t *testing.T) {
 // process stderr rather than the writer run() is handed — an in-process test
 // capturing only run()'s stderr could not see the dump at all.
 func TestBadFlagReportsOnceWithHelpPointer(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), testBinaryName())
-	if out, err := exec.Command("go", "build", "-o", bin).CombinedOutput(); err != nil {
-		t.Fatalf("build test binary: %v\n%s", err, out)
-	}
+	bin := buildTestBinary(t)
 
 	for _, args := range [][]string{{"--typo"}, {"--typo", "--help"}} {
 		t.Run(strings.Join(args, " "), func(t *testing.T) {

--- a/pkg/diffyml/cli/cli.go
+++ b/pkg/diffyml/cli/cli.go
@@ -87,6 +87,14 @@ type CLIConfig struct {
 	// Config file
 	ConfigFile string
 
+	// Concurrency
+	// Jobs is the number of file pairs compared in parallel in directory mode.
+	// 0 means one worker per usable CPU. 1 forces the sequential streaming path,
+	// which keeps only one pair's differences in memory at a time — the escape
+	// hatch for memory-capped environments, since worker count is derived from
+	// the CPU limit but nothing derives it from a memory limit.
+	Jobs int
+
 	// Custom color palette (resolved from config file + env vars)
 	Palette *diffyml.CustomColorPalette
 
@@ -214,6 +222,9 @@ func (c *CLIConfig) initFlags() {
 
 	// Config file
 	c.fs.StringVar(&c.ConfigFile, "config", c.ConfigFile, "path to config file")
+
+	// Concurrency
+	c.fs.IntVar(&c.Jobs, "jobs", c.Jobs, "file pairs compared in parallel in directory mode (0 = one per CPU, 1 = sequential)")
 
 	// Exit code behavior
 	c.fs.BoolVar(&c.SetExitCode, "s", c.SetExitCode, "")
@@ -510,6 +521,10 @@ func (c *CLIConfig) Usage() string {
 	sb.WriteString("      --config string                 path to config file (default: .diffyml.yml in current directory)\n")
 	sb.WriteString("\n")
 
+	// Concurrency
+	sb.WriteString("      --jobs int                      file pairs compared in parallel in directory mode (default 0: one per CPU)\n")
+	sb.WriteString("\n")
+
 	// Other options
 	sb.WriteString("  -s, --set-exit-code                 set program exit code based on differences\n")
 	sb.WriteString("  -h, --help                          show this help\n")
@@ -594,6 +609,11 @@ func (c *CLIConfig) Validate() error {
 	// Neat option constraints
 	if len(c.NeatStripPath) > 0 && !c.Neat {
 		return fmt.Errorf("--neat-strip-path requires --neat")
+	}
+
+	// Concurrency
+	if c.Jobs < 0 {
+		return fmt.Errorf("invalid --jobs %d, must be 0 (one per CPU) or a positive count", c.Jobs)
 	}
 
 	// Validate AI summary configuration

--- a/pkg/diffyml/cli/cli.go
+++ b/pkg/diffyml/cli/cli.go
@@ -117,6 +117,12 @@ func NewCLIConfig() *CLIConfig {
 // initFlags sets up the flag definitions.
 func (c *CLIConfig) initFlags() {
 	c.fs = flag.NewFlagSet("diffyml", flag.ContinueOnError)
+	// On a parse failure the flag package writes the error to its own output and
+	// then dumps its generated flag listing. Both are unwanted: the error is
+	// returned to the caller, which reports it as "Error: ...", and the listing
+	// is a second, differently formatted usage text competing with Usage().
+	// Discarding leaves the caller as the only thing that reports the failure.
+	c.fs.SetOutput(io.Discard)
 
 	// Output options
 	c.fs.StringVar(&c.Output, "o", c.Output, "")

--- a/pkg/diffyml/cli/cli.go
+++ b/pkg/diffyml/cli/cli.go
@@ -93,6 +93,7 @@ type CLIConfig struct {
 	// Exit code behavior
 	SetExitCode bool
 	ShowHelp    bool
+	ShowVersion bool
 
 	// Internal flagset
 	fs *flag.FlagSet
@@ -213,6 +214,8 @@ func (c *CLIConfig) initFlags() {
 	c.fs.BoolVar(&c.SetExitCode, "set-exit-code", c.SetExitCode, "set program exit code based on differences")
 	c.fs.BoolVar(&c.ShowHelp, "h", c.ShowHelp, "")
 	c.fs.BoolVar(&c.ShowHelp, "help", c.ShowHelp, "show help")
+	c.fs.BoolVar(&c.ShowVersion, "V", c.ShowVersion, "")
+	c.fs.BoolVar(&c.ShowVersion, "version", c.ShowVersion, "show version information")
 }
 
 // ParseArgs parses command-line arguments.
@@ -227,6 +230,15 @@ func (c *CLIConfig) ParseArgs(args []string) error {
 
 	if err := c.fs.Parse(reordered); err != nil {
 		return err
+	}
+
+	// --help / --version short-circuit: they need neither file arguments nor a
+	// readable config file, so return before those can fail. Both are real
+	// flags rather than a raw os.Args pre-scan, so a flag *value* that happens
+	// to be "-h" or "-V" (e.g. --mask-placeholder -h) is no longer mistaken
+	// for the flag itself.
+	if c.ShowHelp || c.ShowVersion {
+		return nil
 	}
 
 	// Load and apply config file (CLI flags override config values).

--- a/pkg/diffyml/cli/cli_validation_test.go
+++ b/pkg/diffyml/cli/cli_validation_test.go
@@ -40,6 +40,33 @@ func TestCLIConfig_Validate_InvalidOutput(t *testing.T) {
 	}
 }
 
+func TestCLIConfig_Validate_Jobs(t *testing.T) {
+	// 0 means "one worker per CPU", so only negative counts are rejected.
+	for _, jobs := range []int{0, 1, 2, 64} {
+		cfg := NewCLIConfig()
+		cfg.Jobs = jobs
+		cfg.FromFile = "from.yaml"
+		cfg.ToFile = "to.yaml"
+
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("expected --jobs %d to be accepted, got: %v", jobs, err)
+		}
+	}
+
+	cfg := NewCLIConfig()
+	cfg.Jobs = -1
+	cfg.FromFile = "from.yaml"
+	cfg.ToFile = "to.yaml"
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected an error for a negative --jobs")
+	}
+	if !containsSubstr(err.Error(), "--jobs") {
+		t.Errorf("error should mention --jobs, got: %v", err)
+	}
+}
+
 func TestCLIConfig_Validate_InvalidColor(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.Color = "invalid"

--- a/pkg/diffyml/cli/config.go
+++ b/pkg/diffyml/cli/config.go
@@ -66,6 +66,9 @@ type FileConfig struct {
 	Summary      *bool   `yaml:"summary"`
 	SummaryModel *string `yaml:"summary-model"`
 
+	// Concurrency
+	Jobs *int `yaml:"jobs"`
+
 	// Exit code behavior
 	SetExitCode *bool `yaml:"set-exit-code"`
 
@@ -284,6 +287,11 @@ func (c *CLIConfig) applyFileConfig(fc *FileConfig, cliSet map[string]bool) {
 	}
 	if fc.SummaryModel != nil && notSet("summary-model") {
 		c.SummaryModel = *fc.SummaryModel
+	}
+
+	// Concurrency
+	if fc.Jobs != nil && notSet("jobs") {
+		c.Jobs = *fc.Jobs
 	}
 
 	// Exit code behavior

--- a/pkg/diffyml/cli/config_test.go
+++ b/pkg/diffyml/cli/config_test.go
@@ -45,6 +45,7 @@ chroot-list-to-documents: true
 summary: true
 summary-model: "claude-sonnet-4-20250514"
 set-exit-code: true
+jobs: 3
 colors:
   added: "#6aa3a5"
   removed: "#702d06"
@@ -157,6 +158,11 @@ colors:
 	// Exit code
 	if fc.SetExitCode == nil || !*fc.SetExitCode {
 		t.Error("expected SetExitCode=true")
+	}
+
+	// Concurrency
+	if fc.Jobs == nil || *fc.Jobs != 3 {
+		t.Errorf("expected Jobs=3, got %v", fc.Jobs)
 	}
 
 	// Custom colors
@@ -610,6 +616,24 @@ func TestApplyFileConfig_IntField_CLIOverrides(t *testing.T) {
 
 	if cfg.MultiLineContextLines != 2 {
 		t.Errorf("expected CLI override MultiLineContextLines=2, got %d", cfg.MultiLineContextLines)
+	}
+}
+
+func TestApplyFileConfig_Jobs(t *testing.T) {
+	jobs := 3
+
+	cfg := NewCLIConfig()
+	cfg.applyFileConfig(&FileConfig{Jobs: &jobs}, map[string]bool{})
+	if cfg.Jobs != 3 {
+		t.Errorf("expected Jobs=3 from config file, got %d", cfg.Jobs)
+	}
+
+	// An explicit --jobs on the command line wins over the config file.
+	cfg = NewCLIConfig()
+	cfg.Jobs = 1
+	cfg.applyFileConfig(&FileConfig{Jobs: &jobs}, map[string]bool{"jobs": true})
+	if cfg.Jobs != 1 {
+		t.Errorf("expected CLI override Jobs=1, got %d", cfg.Jobs)
 	}
 }
 

--- a/pkg/diffyml/cli/directory.go
+++ b/pkg/diffyml/cli/directory.go
@@ -172,12 +172,14 @@ type dirPairResult struct {
 	err   error
 }
 
-// dirWorkerCount returns how many goroutines the compare phase should use.
-// A result below 2 means parallelism cannot help (one pair, or one usable CPU)
-// and the caller should stream instead, which avoids buffering every pair's
-// diffs. GOMAXPROCS is container-aware, so this respects CPU limits in CI.
-func dirWorkerCount(pairCount int) int {
-	return min(runtime.GOMAXPROCS(0), pairCount)
+// dirCompareWorkers reports how many goroutines the compare phase should use,
+// and whether running it in parallel is worth doing at all. parallel is false
+// for a single pair or a single usable CPU: goroutines cannot help there, and
+// the caller's streaming path avoids buffering every pair's diffs. GOMAXPROCS is
+// container-aware, so this respects CPU limits in CI.
+func dirCompareWorkers(pairCount int) (workers int, parallel bool) {
+	workers = min(runtime.GOMAXPROCS(0), pairCount)
+	return workers, workers >= 2
 }
 
 // processDirPairs runs processDirPair over every pair using the given number of
@@ -345,17 +347,17 @@ func runDirectory(cfg *CLIConfig, rc *RunConfig, fromDir, toDir string) *ExitRes
 	}
 	// Formatting and writing always happen on this goroutine, in pair order, so
 	// output and the color/terminal state are identical on both paths below.
-	if workers := dirWorkerCount(len(pairs)); workers < 2 {
+	if workers, parallel := dirCompareWorkers(len(pairs)); parallel {
+		results := processDirPairs(pairs, workers, rc.FilePairs, compareOpts, maskOpts, filterOpts)
+		for i, pair := range pairs {
+			c.handlePairResult(pair, results[i].diffs, results[i].err)
+		}
+	} else {
 		// Nothing to gain from goroutines: compare and emit one pair at a time
 		// so only a single pair's diffs are live, as before parallelism existed.
 		for _, pair := range pairs {
 			diffs, diffErr := processDirPair(pair, rc.FilePairs, compareOpts, maskOpts, filterOpts)
 			c.handlePairResult(pair, diffs, diffErr)
-		}
-	} else {
-		results := processDirPairs(pairs, workers, rc.FilePairs, compareOpts, maskOpts, filterOpts)
-		for i, pair := range pairs {
-			c.handlePairResult(pair, results[i].diffs, results[i].err)
 		}
 	}
 

--- a/pkg/diffyml/cli/directory.go
+++ b/pkg/diffyml/cli/directory.go
@@ -175,10 +175,19 @@ type dirPairResult struct {
 // dirCompareWorkers reports how many goroutines the compare phase should use,
 // and whether running it in parallel is worth doing at all. parallel is false
 // for a single pair or a single usable CPU: goroutines cannot help there, and
-// the caller's streaming path avoids buffering every pair's diffs. GOMAXPROCS is
-// container-aware, so this respects CPU limits in CI.
-func dirCompareWorkers(pairCount int) (workers int, parallel bool) {
-	workers = min(runtime.GOMAXPROCS(0), pairCount)
+// the caller's streaming path avoids buffering every pair's diffs.
+//
+// jobs is --jobs: 0 means one worker per usable CPU, and any positive value is
+// taken as given (still capped by pairCount, since idle workers are pointless).
+// GOMAXPROCS is container-aware, so the default respects CPU limits in CI, but
+// nothing derives a worker count from a *memory* limit — --jobs 1 is how a
+// memory-capped caller gets the streaming path back. Negative values are
+// rejected by CLIConfig.Validate before reaching here.
+func dirCompareWorkers(pairCount, jobs int) (workers int, parallel bool) {
+	if jobs <= 0 {
+		jobs = runtime.GOMAXPROCS(0)
+	}
+	workers = min(jobs, pairCount)
 	return workers, workers >= 2
 }
 
@@ -201,7 +210,10 @@ func dirCompareWorkers(pairCount int) (workers int, parallel bool) {
 // 160-pair batch 38% to save 74%. GOGC=off collapses the gap to ~1%, which
 // identifies collection frequency rather than the buffering itself as the cost.
 // The curve is monotonic with no knee, so there is no bound that is close to
-// free — every megabyte saved buys proportional slowdown.
+// free — every megabyte saved buys proportional slowdown. Callers who need the
+// memory back instead of the speed pick the trade-off explicitly with --jobs:
+// on that same corpus, --jobs 1 peaks at 18 MB against 79 MB for 10 workers,
+// for roughly 1.9x the wall time.
 func processDirPairs(pairs []diffyml.FilePair, workers int, filePairs map[string][2][]byte,
 	compareOpts *diffyml.Options, maskOpts diffyml.MaskOptions, filterOpts *diffyml.FilterOptions,
 ) []dirPairResult {
@@ -347,7 +359,7 @@ func runDirectory(cfg *CLIConfig, rc *RunConfig, fromDir, toDir string) *ExitRes
 	}
 	// Formatting and writing always happen on this goroutine, in pair order, so
 	// output and the color/terminal state are identical on both paths below.
-	if workers, parallel := dirCompareWorkers(len(pairs)); parallel {
+	if workers, parallel := dirCompareWorkers(len(pairs), cfg.Jobs); parallel {
 		results := processDirPairs(pairs, workers, rc.FilePairs, compareOpts, maskOpts, filterOpts)
 		for i, pair := range pairs {
 			c.handlePairResult(pair, results[i].diffs, results[i].err)

--- a/pkg/diffyml/cli/directory.go
+++ b/pkg/diffyml/cli/directory.go
@@ -190,6 +190,16 @@ func dirWorkerCount(pairCount int) int {
 // Results are buffered so the caller can replay them in pair order, keeping
 // output byte-identical to the streaming path. Peak memory therefore grows with
 // total diffs, matching what structured formatters and --summary already hold.
+//
+// Bounding that buffer was tried and measured, and is deliberately not done.
+// Emitting in batches does cap peak memory, but it also shrinks the live heap,
+// and Go's GC then runs proportionally more cycles for the same allocation
+// volume. On 3000 differing manifests with 10 workers: a 1280-pair batch cost
+// 10% wall time to save 43% peak RSS, a 640-pair batch 18% to save 61%, and a
+// 160-pair batch 38% to save 74%. GOGC=off collapses the gap to ~1%, which
+// identifies collection frequency rather than the buffering itself as the cost.
+// The curve is monotonic with no knee, so there is no bound that is close to
+// free — every megabyte saved buys proportional slowdown.
 func processDirPairs(pairs []diffyml.FilePair, workers int, filePairs map[string][2][]byte,
 	compareOpts *diffyml.Options, maskOpts diffyml.MaskOptions, filterOpts *diffyml.FilterOptions,
 ) []dirPairResult {

--- a/pkg/diffyml/cli/directory.go
+++ b/pkg/diffyml/cli/directory.go
@@ -7,8 +7,11 @@ package cli
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/szhekpisov/diffyml/pkg/diffyml"
 )
@@ -162,6 +165,56 @@ func processDirPair(pair diffyml.FilePair, filePairs map[string][2][]byte, compa
 	return diffs, nil
 }
 
+// dirPairResult is the outcome of processing one file pair, held so results can
+// be replayed in pair order regardless of the order they finish in.
+type dirPairResult struct {
+	diffs []diffyml.Difference
+	err   error
+}
+
+// dirWorkerCount returns how many goroutines the compare phase should use.
+// A result below 2 means parallelism cannot help (one pair, or one usable CPU)
+// and the caller should stream instead, which avoids buffering every pair's
+// diffs. GOMAXPROCS is container-aware, so this respects CPU limits in CI.
+func dirWorkerCount(pairCount int) int {
+	return min(runtime.GOMAXPROCS(0), pairCount)
+}
+
+// processDirPairs runs processDirPair over every pair using the given number of
+// workers, which the caller guarantees is at least 2. Each worker writes only
+// to its own results[i] slot, so the index counter is the only synchronization
+// needed; everything shared (pairs, filePairs, and the three option structs) is
+// read-only for the duration — Compare, MaskDifferences and FilterDiffsWithRegexp
+// all treat their options as immutable and compile regexes per call.
+//
+// Results are buffered so the caller can replay them in pair order, keeping
+// output byte-identical to the streaming path. Peak memory therefore grows with
+// total diffs, matching what structured formatters and --summary already hold.
+func processDirPairs(pairs []diffyml.FilePair, workers int, filePairs map[string][2][]byte,
+	compareOpts *diffyml.Options, maskOpts diffyml.MaskOptions, filterOpts *diffyml.FilterOptions,
+) []dirPairResult {
+	results := make([]dirPairResult, len(pairs))
+
+	var next atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= len(pairs) {
+					return
+				}
+				results[i].diffs, results[i].err = processDirPair(pairs[i], filePairs, compareOpts, maskOpts, filterOpts)
+			}
+		}()
+	}
+	wg.Wait()
+
+	return results
+}
+
 // setupDirFormatting creates the formatter and format options for directory mode.
 func setupDirFormatting(cfg *CLIConfig) (diffyml.Formatter, *diffyml.FormatOptions, error) {
 	formatter, err := diffyml.FormatterByName(cfg.Output)
@@ -204,6 +257,19 @@ type dirPairCollector struct {
 	summaryEntries []summaryEntry
 	hasDiffs       bool
 	hasErrors      bool
+}
+
+// handlePairResult reports a pair's processing error, or collects its diffs.
+// Shared by the streaming and parallel paths so both emit identically.
+func (c *dirPairCollector) handlePairResult(pair diffyml.FilePair, diffs []diffyml.Difference, err error) {
+	if err != nil {
+		fmt.Fprintf(c.rc.Stderr, "Error: %v\n", err)
+		c.hasErrors = true
+		return
+	}
+	if len(diffs) > 0 {
+		c.collectPairResult(pair, diffs)
+	}
 }
 
 // collectPairResult records the diff results for a single file pair, emitting output as needed.
@@ -267,15 +333,19 @@ func runDirectory(cfg *CLIConfig, rc *RunConfig, fromDir, toDir string) *ExitRes
 		isBriefSummary: cfg.Output == "brief" && cfg.Summary,
 		wantSummary:    cfg.Summary,
 	}
-	for _, pair := range pairs {
-		diffs, diffErr := processDirPair(pair, rc.FilePairs, compareOpts, maskOpts, filterOpts)
-		if diffErr != nil {
-			fmt.Fprintf(rc.Stderr, "Error: %v\n", diffErr)
-			c.hasErrors = true
-			continue
+	// Formatting and writing always happen on this goroutine, in pair order, so
+	// output and the color/terminal state are identical on both paths below.
+	if workers := dirWorkerCount(len(pairs)); workers < 2 {
+		// Nothing to gain from goroutines: compare and emit one pair at a time
+		// so only a single pair's diffs are live, as before parallelism existed.
+		for _, pair := range pairs {
+			diffs, diffErr := processDirPair(pair, rc.FilePairs, compareOpts, maskOpts, filterOpts)
+			c.handlePairResult(pair, diffs, diffErr)
 		}
-		if len(diffs) > 0 {
-			c.collectPairResult(pair, diffs)
+	} else {
+		results := processDirPairs(pairs, workers, rc.FilePairs, compareOpts, maskOpts, filterOpts)
+		for i, pair := range pairs {
+			c.handlePairResult(pair, results[i].diffs, results[i].err)
 		}
 	}
 

--- a/pkg/diffyml/cli/directory_parallel_test.go
+++ b/pkg/diffyml/cli/directory_parallel_test.go
@@ -7,6 +7,15 @@ import (
 	"testing"
 )
 
+// testWorkers is the GOMAXPROCS value these tests use to force the parallel
+// path. It is a fixed number rather than runtime.NumCPU() on purpose: GOMAXPROCS
+// is not capped by the CPU count, so raising it spawns real workers and
+// interleaves them even on a single-core runner. The race detector's
+// happens-before analysis does not need true parallelism to find a race, so
+// pinning it here keeps the ordering guarantees under test everywhere —
+// including the one-CPU CI containers where a latent bug is easiest to miss.
+const testWorkers = 4
+
 // withGOMAXPROCS pins GOMAXPROCS for the duration of a test so both the
 // streaming path (workers < 2) and the parallel path can be exercised
 // deterministically. These tests must not call t.Parallel(), since GOMAXPROCS
@@ -64,17 +73,13 @@ func runDirectoryCapture(t *testing.T, output string, pairs map[string][2][]byte
 // parallel compare phase: results are replayed in pair order, so output must be
 // byte-identical to the single-worker streaming path for every output format.
 func TestRunDirectory_ParallelMatchesSequential(t *testing.T) {
-	if runtime.NumCPU() < 2 {
-		t.Skip("needs at least 2 CPUs to exercise the parallel path")
-	}
-
 	formats := []string{"detailed", "compact", "brief", "json", "json-patch", "github", "gitlab", "gitea"}
 	for _, format := range formats {
 		t.Run(format, func(t *testing.T) {
 			withGOMAXPROCS(t, 1)
 			seqOut, seqErr, seqCode := runDirectoryCapture(t, format, buildParallelPairs(60))
 
-			withGOMAXPROCS(t, runtime.NumCPU())
+			withGOMAXPROCS(t, testWorkers)
 			parOut, parErr, parCode := runDirectoryCapture(t, format, buildParallelPairs(60))
 
 			if seqOut != parOut {
@@ -95,16 +100,19 @@ func TestRunDirectory_ParallelMatchesSequential(t *testing.T) {
 // leaking into the output: repeated parallel runs over identical input must
 // produce identical bytes.
 func TestRunDirectory_ParallelIsDeterministic(t *testing.T) {
-	if runtime.NumCPU() < 2 {
-		t.Skip("needs at least 2 CPUs to exercise the parallel path")
-	}
-	withGOMAXPROCS(t, runtime.NumCPU())
+	withGOMAXPROCS(t, testWorkers)
 
-	want, _, _ := runDirectoryCapture(t, "detailed", buildParallelPairs(60))
+	wantOut, wantErr, wantCode := runDirectoryCapture(t, "detailed", buildParallelPairs(60))
 	for i := range 12 {
-		got, _, _ := runDirectoryCapture(t, "detailed", buildParallelPairs(60))
-		if got != want {
-			t.Fatalf("run %d produced different output than run 0", i+1)
+		gotOut, gotErr, gotCode := runDirectoryCapture(t, "detailed", buildParallelPairs(60))
+		if gotOut != wantOut {
+			t.Fatalf("run %d produced different stdout than run 0", i+1)
+		}
+		if gotErr != wantErr {
+			t.Fatalf("run %d produced different stderr than run 0: %q vs %q", i+1, gotErr, wantErr)
+		}
+		if gotCode != wantCode {
+			t.Fatalf("run %d produced exit code %d, want %d", i+1, gotCode, wantCode)
 		}
 	}
 }
@@ -113,10 +121,6 @@ func TestRunDirectory_ParallelIsDeterministic(t *testing.T) {
 // reported in pair order rather than completion order, and that a failing pair
 // does not suppress the diffs of the pairs around it.
 func TestRunDirectory_ParallelPreservesErrorOrder(t *testing.T) {
-	if runtime.NumCPU() < 2 {
-		t.Skip("needs at least 2 CPUs to exercise the parallel path")
-	}
-
 	pairs := buildParallelPairs(30)
 	badNames := []string{"file005.yaml", "file015.yaml", "file025.yaml"}
 	for _, name := range badNames {
@@ -126,7 +130,7 @@ func TestRunDirectory_ParallelPreservesErrorOrder(t *testing.T) {
 	withGOMAXPROCS(t, 1)
 	seqOut, seqErr, seqCode := runDirectoryCapture(t, "detailed", pairs)
 
-	withGOMAXPROCS(t, runtime.NumCPU())
+	withGOMAXPROCS(t, testWorkers)
 	parOut, parErr, parCode := runDirectoryCapture(t, "detailed", pairs)
 
 	if seqErr != parErr {
@@ -164,7 +168,7 @@ func TestRunDirectory_ParallelPreservesErrorOrder(t *testing.T) {
 // by the pair count so a single pair never spawns workers, and it never exceeds
 // GOMAXPROCS.
 func TestDirWorkerCount(t *testing.T) {
-	withGOMAXPROCS(t, 4)
+	withGOMAXPROCS(t, testWorkers)
 
 	tests := []struct {
 		pairCount int
@@ -173,8 +177,8 @@ func TestDirWorkerCount(t *testing.T) {
 		{0, 0},
 		{1, 1},
 		{2, 2},
-		{4, 4},
-		{100, 4}, // capped at GOMAXPROCS
+		{testWorkers, testWorkers},
+		{100, testWorkers}, // capped at GOMAXPROCS
 	}
 	for _, tt := range tests {
 		if got := dirWorkerCount(tt.pairCount); got != tt.want {
@@ -191,7 +195,8 @@ func TestDirWorkerCount(t *testing.T) {
 // TestRunDirectory_SinglePairUsesStreamingPath confirms a one-pair run still
 // works when workers < 2 short-circuits the parallel path.
 func TestRunDirectory_SinglePairUsesStreamingPath(t *testing.T) {
-	withGOMAXPROCS(t, runtime.NumCPU())
+	// GOMAXPROCS is high, so only the pair-count cap can force streaming here.
+	withGOMAXPROCS(t, testWorkers)
 
 	if got := dirWorkerCount(1); got >= 2 {
 		t.Fatalf("dirWorkerCount(1) = %d, expected < 2 so streaming is used", got)

--- a/pkg/diffyml/cli/directory_parallel_test.go
+++ b/pkg/diffyml/cli/directory_parallel_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// withGOMAXPROCS pins GOMAXPROCS for the duration of a test so both the
+// streaming path (workers < 2) and the parallel path can be exercised
+// deterministically. These tests must not call t.Parallel(), since GOMAXPROCS
+// is process-global.
+func withGOMAXPROCS(t *testing.T, n int) {
+	t.Helper()
+	prev := runtime.GOMAXPROCS(n)
+	t.Cleanup(func() { runtime.GOMAXPROCS(prev) })
+}
+
+// buildParallelPairs returns n in-memory file pairs with differing content.
+// Every other pair is given multi-key content so pairs vary in comparison cost,
+// which makes workers finish out of index order.
+func buildParallelPairs(n int) map[string][2][]byte {
+	pairs := make(map[string][2][]byte, n)
+	for i := range n {
+		name := fmt.Sprintf("file%03d.yaml", i)
+		if i%2 == 0 {
+			pairs[name] = [2][]byte{
+				[]byte(fmt.Sprintf("name: svc%d\nreplicas: 1\n", i)),
+				[]byte(fmt.Sprintf("name: svc%d\nreplicas: 2\n", i)),
+			}
+			continue
+		}
+		var from, to strings.Builder
+		for k := range 40 {
+			fmt.Fprintf(&from, "key%02d: old-%d-%d\n", k, i, k)
+			fmt.Fprintf(&to, "key%02d: new-%d-%d\n", k, i, k)
+		}
+		pairs[name] = [2][]byte{[]byte(from.String()), []byte(to.String())}
+	}
+	return pairs
+}
+
+// runDirectoryCapture runs directory mode over the given pairs and returns
+// stdout, stderr and the exit code.
+func runDirectoryCapture(t *testing.T, output string, pairs map[string][2][]byte) (string, string, int) {
+	t.Helper()
+	cfg := NewCLIConfig()
+	cfg.Color = "never"
+	cfg.SetExitCode = true
+	cfg.Output = output
+
+	rc := NewRunConfig()
+	var stdout, stderr strings.Builder
+	rc.Stdout = &stdout
+	rc.Stderr = &stderr
+	rc.FilePairs = pairs
+
+	result := runDirectory(cfg, rc, "", "")
+	return stdout.String(), stderr.String(), result.Code
+}
+
+// TestRunDirectory_ParallelMatchesSequential is the core guarantee of the
+// parallel compare phase: results are replayed in pair order, so output must be
+// byte-identical to the single-worker streaming path for every output format.
+func TestRunDirectory_ParallelMatchesSequential(t *testing.T) {
+	if runtime.NumCPU() < 2 {
+		t.Skip("needs at least 2 CPUs to exercise the parallel path")
+	}
+
+	formats := []string{"detailed", "compact", "brief", "json", "json-patch", "github", "gitlab", "gitea"}
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			withGOMAXPROCS(t, 1)
+			seqOut, seqErr, seqCode := runDirectoryCapture(t, format, buildParallelPairs(60))
+
+			withGOMAXPROCS(t, runtime.NumCPU())
+			parOut, parErr, parCode := runDirectoryCapture(t, format, buildParallelPairs(60))
+
+			if seqOut != parOut {
+				t.Errorf("stdout differs between sequential and parallel paths\nsequential (%d bytes):\n%s\nparallel (%d bytes):\n%s",
+					len(seqOut), seqOut, len(parOut), parOut)
+			}
+			if seqErr != parErr {
+				t.Errorf("stderr differs: sequential %q, parallel %q", seqErr, parErr)
+			}
+			if seqCode != parCode {
+				t.Errorf("exit code differs: sequential %d, parallel %d", seqCode, parCode)
+			}
+		})
+	}
+}
+
+// TestRunDirectory_ParallelIsDeterministic guards against completion order
+// leaking into the output: repeated parallel runs over identical input must
+// produce identical bytes.
+func TestRunDirectory_ParallelIsDeterministic(t *testing.T) {
+	if runtime.NumCPU() < 2 {
+		t.Skip("needs at least 2 CPUs to exercise the parallel path")
+	}
+	withGOMAXPROCS(t, runtime.NumCPU())
+
+	want, _, _ := runDirectoryCapture(t, "detailed", buildParallelPairs(60))
+	for i := range 12 {
+		got, _, _ := runDirectoryCapture(t, "detailed", buildParallelPairs(60))
+		if got != want {
+			t.Fatalf("run %d produced different output than run 0", i+1)
+		}
+	}
+}
+
+// TestRunDirectory_ParallelPreservesErrorOrder verifies that per-pair errors are
+// reported in pair order rather than completion order, and that a failing pair
+// does not suppress the diffs of the pairs around it.
+func TestRunDirectory_ParallelPreservesErrorOrder(t *testing.T) {
+	if runtime.NumCPU() < 2 {
+		t.Skip("needs at least 2 CPUs to exercise the parallel path")
+	}
+
+	pairs := buildParallelPairs(30)
+	badNames := []string{"file005.yaml", "file015.yaml", "file025.yaml"}
+	for _, name := range badNames {
+		pairs[name] = [2][]byte{[]byte("key: old\n"), []byte(":\nbad yaml [[[")}
+	}
+
+	withGOMAXPROCS(t, 1)
+	seqOut, seqErr, seqCode := runDirectoryCapture(t, "detailed", pairs)
+
+	withGOMAXPROCS(t, runtime.NumCPU())
+	parOut, parErr, parCode := runDirectoryCapture(t, "detailed", pairs)
+
+	if seqErr != parErr {
+		t.Errorf("stderr order differs between paths\nsequential:\n%s\nparallel:\n%s", seqErr, parErr)
+	}
+	if seqOut != parOut {
+		t.Error("stdout differs between sequential and parallel paths when some pairs fail")
+	}
+	if seqCode != parCode {
+		t.Errorf("exit code differs: sequential %d, parallel %d", seqCode, parCode)
+	}
+
+	// Errors must appear in pair order, matching the sorted pair plan.
+	lastIdx := -1
+	for _, name := range badNames {
+		idx := strings.Index(parErr, name)
+		if idx < 0 {
+			t.Fatalf("expected an error mentioning %s, got:\n%s", name, parErr)
+		}
+		if idx < lastIdx {
+			t.Errorf("error for %s reported out of pair order", name)
+		}
+		lastIdx = idx
+	}
+
+	// A healthy pair on either side of a failing one still produces output.
+	for _, name := range []string{"file004.yaml", "file006.yaml"} {
+		if !strings.Contains(parOut, name) {
+			t.Errorf("expected output for %s alongside failing pairs", name)
+		}
+	}
+}
+
+// TestDirWorkerCount checks the streaming/parallel decision: the count is capped
+// by the pair count so a single pair never spawns workers, and it never exceeds
+// GOMAXPROCS.
+func TestDirWorkerCount(t *testing.T) {
+	withGOMAXPROCS(t, 4)
+
+	tests := []struct {
+		pairCount int
+		want      int
+	}{
+		{0, 0},
+		{1, 1},
+		{2, 2},
+		{4, 4},
+		{100, 4}, // capped at GOMAXPROCS
+	}
+	for _, tt := range tests {
+		if got := dirWorkerCount(tt.pairCount); got != tt.want {
+			t.Errorf("dirWorkerCount(%d) = %d, want %d", tt.pairCount, got, tt.want)
+		}
+	}
+
+	withGOMAXPROCS(t, 1)
+	if got := dirWorkerCount(100); got != 1 {
+		t.Errorf("with GOMAXPROCS=1, dirWorkerCount(100) = %d, want 1 (streaming path)", got)
+	}
+}
+
+// TestRunDirectory_SinglePairUsesStreamingPath confirms a one-pair run still
+// works when workers < 2 short-circuits the parallel path.
+func TestRunDirectory_SinglePairUsesStreamingPath(t *testing.T) {
+	withGOMAXPROCS(t, runtime.NumCPU())
+
+	if got := dirWorkerCount(1); got >= 2 {
+		t.Fatalf("dirWorkerCount(1) = %d, expected < 2 so streaming is used", got)
+	}
+
+	stdout, _, code := runDirectoryCapture(t, "detailed", map[string][2][]byte{
+		"only.yaml": {[]byte("a: 1\n"), []byte("a: 2\n")},
+	})
+	if code != ExitCodeDifferences {
+		t.Errorf("expected exit %d, got %d", ExitCodeDifferences, code)
+	}
+	if !strings.Contains(stdout, "only.yaml") {
+		t.Errorf("expected output for only.yaml, got: %q", stdout)
+	}
+}

--- a/pkg/diffyml/cli/directory_parallel_test.go
+++ b/pkg/diffyml/cli/directory_parallel_test.go
@@ -51,13 +51,17 @@ func buildParallelPairs(n int) map[string][2][]byte {
 }
 
 // runDirectoryCapture runs directory mode over the given pairs and returns
-// stdout, stderr and the exit code.
-func runDirectoryCapture(t *testing.T, output string, pairs map[string][2][]byte) (string, string, int) {
+// stdout, stderr and the exit code. Any tweak functions are applied to the
+// config before the run, for tests that need options beyond the defaults.
+func runDirectoryCapture(t *testing.T, output string, pairs map[string][2][]byte, tweak ...func(*CLIConfig)) (string, string, int) {
 	t.Helper()
 	cfg := NewCLIConfig()
 	cfg.Color = "never"
 	cfg.SetExitCode = true
 	cfg.Output = output
+	for _, fn := range tweak {
+		fn(cfg)
+	}
 
 	rc := NewRunConfig()
 	var stdout, stderr strings.Builder
@@ -172,27 +176,83 @@ func TestDirCompareWorkers(t *testing.T) {
 
 	tests := []struct {
 		pairCount    int
+		jobs         int
 		want         int
 		wantParallel bool
 	}{
-		{0, 0, false},
-		{1, 1, false}, // a single pair has nothing to overlap with
-		{2, 2, true},
-		{testWorkers, testWorkers, true},
-		{100, testWorkers, true}, // capped at GOMAXPROCS
+		{0, 0, 0, false},
+		{1, 0, 1, false}, // a single pair has nothing to overlap with
+		{2, 0, 2, true},
+		{testWorkers, 0, testWorkers, true},
+		{100, 0, testWorkers, true},                   // capped at GOMAXPROCS
+		{100, 1, 1, false},                            // --jobs 1: the caller asked for streaming
+		{100, 2, 2, true},                             // --jobs below GOMAXPROCS wins
+		{100, testWorkers * 4, testWorkers * 4, true}, // --jobs above GOMAXPROCS is honored
+		{3, testWorkers * 4, 3, true},                 // ...but never exceeds the pair count
+		{1, 8, 1, false},                              // one pair stays sequential whatever --jobs says
 	}
 	for _, tt := range tests {
-		got, parallel := dirCompareWorkers(tt.pairCount)
+		got, parallel := dirCompareWorkers(tt.pairCount, tt.jobs)
 		if got != tt.want || parallel != tt.wantParallel {
-			t.Errorf("dirCompareWorkers(%d) = (%d, %t), want (%d, %t)",
-				tt.pairCount, got, parallel, tt.want, tt.wantParallel)
+			t.Errorf("dirCompareWorkers(%d, jobs=%d) = (%d, %t), want (%d, %t)",
+				tt.pairCount, tt.jobs, got, parallel, tt.want, tt.wantParallel)
 		}
 	}
 
 	// One usable CPU: plenty of pairs, but still nothing to gain.
 	withGOMAXPROCS(t, 1)
-	if got, parallel := dirCompareWorkers(100); got != 1 || parallel {
-		t.Errorf("with GOMAXPROCS=1, dirCompareWorkers(100) = (%d, %t), want (1, false)", got, parallel)
+	if got, parallel := dirCompareWorkers(100, 0); got != 1 || parallel {
+		t.Errorf("with GOMAXPROCS=1, dirCompareWorkers(100, 0) = (%d, %t), want (1, false)", got, parallel)
+	}
+	// ...unless --jobs asks for more anyway: worker count is not capped by the
+	// CPU count, and oversubscribing is the caller's call to make.
+	if got, parallel := dirCompareWorkers(100, 4); got != 4 || !parallel {
+		t.Errorf("with GOMAXPROCS=1, dirCompareWorkers(100, 4) = (%d, %t), want (4, true)", got, parallel)
+	}
+}
+
+// TestRunDirectory_JobsOneForcesStreaming covers --jobs as the memory escape
+// hatch: with CPUs available it must still take the sequential path, and produce
+// exactly what the parallel path produces.
+func TestRunDirectory_JobsOneForcesStreaming(t *testing.T) {
+	withGOMAXPROCS(t, testWorkers)
+
+	parOut, parErr, parCode := runDirectoryCapture(t, "detailed", buildParallelPairs(60))
+	seqOut, seqErr, seqCode := runDirectoryCapture(t, "detailed", buildParallelPairs(60),
+		func(cfg *CLIConfig) { cfg.Jobs = 1 })
+
+	if seqOut != parOut {
+		t.Errorf("--jobs 1 stdout differs from the parallel path (%d vs %d bytes)", len(seqOut), len(parOut))
+	}
+	if seqErr != parErr {
+		t.Errorf("--jobs 1 stderr differs: %q vs %q", seqErr, parErr)
+	}
+	if seqCode != parCode {
+		t.Errorf("--jobs 1 exit code differs: %d vs %d", seqCode, parCode)
+	}
+}
+
+// TestRunDirectory_JobsCapsWorkers exercises a bounded worker count end to end,
+// since dirCompareWorkers is only half the contract: processDirPairs has to
+// cover all pairs with fewer workers than pairs, in order.
+func TestRunDirectory_JobsCapsWorkers(t *testing.T) {
+	withGOMAXPROCS(t, testWorkers)
+
+	wantOut, wantErr, wantCode := runDirectoryCapture(t, "detailed", buildParallelPairs(60),
+		func(cfg *CLIConfig) { cfg.Jobs = 1 })
+
+	for _, jobs := range []int{2, 3, testWorkers * 4} {
+		gotOut, gotErr, gotCode := runDirectoryCapture(t, "detailed", buildParallelPairs(60),
+			func(cfg *CLIConfig) { cfg.Jobs = jobs })
+		if gotOut != wantOut {
+			t.Errorf("--jobs %d stdout differs from --jobs 1", jobs)
+		}
+		if gotErr != wantErr {
+			t.Errorf("--jobs %d stderr differs from --jobs 1: %q vs %q", jobs, gotErr, wantErr)
+		}
+		if gotCode != wantCode {
+			t.Errorf("--jobs %d exit code %d, want %d", jobs, gotCode, wantCode)
+		}
 	}
 }
 
@@ -202,7 +262,7 @@ func TestRunDirectory_SinglePairUsesStreamingPath(t *testing.T) {
 	// GOMAXPROCS is high, so only the pair-count cap can force streaming here.
 	withGOMAXPROCS(t, testWorkers)
 
-	if _, parallel := dirCompareWorkers(1); parallel {
+	if _, parallel := dirCompareWorkers(1, 0); parallel {
 		t.Fatal("expected a single pair to take the streaming path")
 	}
 

--- a/pkg/diffyml/cli/directory_parallel_test.go
+++ b/pkg/diffyml/cli/directory_parallel_test.go
@@ -50,6 +50,54 @@ func buildParallelPairs(n int) map[string][2][]byte {
 	return pairs
 }
 
+// buildK8sPairs returns n in-memory manifest pairs shaped to exercise the
+// option-driven parts of the compare phase: Kubernetes entity detection and
+// rename detection, Secret masking, x509 inspection, and the neat bundle.
+func buildK8sPairs(n int) map[string][2][]byte {
+	pairs := make(map[string][2][]byte, n)
+	for i := range n {
+		from := fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: svc%d
+  namespace: default
+  annotations:
+    meta.helm.sh/release-name: r%d
+    kubectl.kubernetes.io/last-applied-configuration: '{"a":1}'
+  labels:
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: c
+          image: nginx:1.1
+          env:
+            - name: PASSWORD
+              value: hunter2-%d
+status:
+  readyReplicas: 1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s%d
+data:
+  password: aHVudGVyMg==
+`, i, i, i, i)
+		to := strings.NewReplacer(
+			"replicas: 1", "replicas: 3",
+			"nginx:1.1", "nginx:1.2",
+			"hunter2-", "hunter3-",
+			"readyReplicas: 1", "readyReplicas: 3",
+			"aHVudGVyMg==", "aHVudGVyMw==",
+		).Replace(from)
+		pairs[fmt.Sprintf("manifest%03d.yaml", i)] = [2][]byte{[]byte(from), []byte(to)}
+	}
+	return pairs
+}
+
 // runDirectoryCapture runs directory mode over the given pairs and returns
 // stdout, stderr and the exit code. Any tweak functions are applied to the
 // config before the run, for tests that need options beyond the defaults.
@@ -97,6 +145,44 @@ func TestRunDirectory_ParallelMatchesSequential(t *testing.T) {
 				t.Errorf("exit code differs: sequential %d, parallel %d", seqCode, parCode)
 			}
 		})
+	}
+}
+
+// TestRunDirectory_ParallelMatchesSequentialWithOptions extends the equivalence
+// guarantee to the option structs the workers share. Those are what the
+// safety argument for sharing rests on — Compare, MaskDifferences and
+// FilterDiffsWithRegexp treating their options as immutable and compiling
+// regexes per call — and the default-config tests exercise none of them.
+func TestRunDirectory_ParallelMatchesSequentialWithOptions(t *testing.T) {
+	heavy := func(cfg *CLIConfig) {
+		cfg.DetectKubernetes = true
+		cfg.DetectRenames = true
+		cfg.MaskSecrets = true
+		cfg.MaskPathRegexp = []string{".*[Pp]assword.*"}
+		cfg.Neat = true
+		cfg.FilterRegexp = []string{".*"}
+		cfg.ExcludeRegexp = []string{"nothing-matches-this"}
+		cfg.MultiLineContextLines = 2
+	}
+
+	withGOMAXPROCS(t, 1)
+	seqOut, seqErr, seqCode := runDirectoryCapture(t, "detailed", buildK8sPairs(40), heavy)
+
+	withGOMAXPROCS(t, testWorkers)
+	parOut, parErr, parCode := runDirectoryCapture(t, "detailed", buildK8sPairs(40), heavy)
+
+	if seqOut == "" {
+		t.Fatal("no output produced; the comparison is not exercising anything")
+	}
+	if seqOut != parOut {
+		t.Errorf("stdout differs with kubernetes/mask/neat/filter options set (%d vs %d bytes)",
+			len(seqOut), len(parOut))
+	}
+	if seqErr != parErr {
+		t.Errorf("stderr differs: sequential %q, parallel %q", seqErr, parErr)
+	}
+	if seqCode != parCode {
+		t.Errorf("exit code differs: sequential %d, parallel %d", seqCode, parCode)
 	}
 }
 

--- a/pkg/diffyml/cli/directory_parallel_test.go
+++ b/pkg/diffyml/cli/directory_parallel_test.go
@@ -164,42 +164,46 @@ func TestRunDirectory_ParallelPreservesErrorOrder(t *testing.T) {
 	}
 }
 
-// TestDirWorkerCount checks the streaming/parallel decision: the count is capped
-// by the pair count so a single pair never spawns workers, and it never exceeds
-// GOMAXPROCS.
-func TestDirWorkerCount(t *testing.T) {
+// TestDirCompareWorkers checks both halves of the streaming/parallel decision:
+// the count is capped by the pair count so a single pair never spawns workers
+// and never exceeds GOMAXPROCS, and the parallel flag agrees with it.
+func TestDirCompareWorkers(t *testing.T) {
 	withGOMAXPROCS(t, testWorkers)
 
 	tests := []struct {
-		pairCount int
-		want      int
+		pairCount    int
+		want         int
+		wantParallel bool
 	}{
-		{0, 0},
-		{1, 1},
-		{2, 2},
-		{testWorkers, testWorkers},
-		{100, testWorkers}, // capped at GOMAXPROCS
+		{0, 0, false},
+		{1, 1, false}, // a single pair has nothing to overlap with
+		{2, 2, true},
+		{testWorkers, testWorkers, true},
+		{100, testWorkers, true}, // capped at GOMAXPROCS
 	}
 	for _, tt := range tests {
-		if got := dirWorkerCount(tt.pairCount); got != tt.want {
-			t.Errorf("dirWorkerCount(%d) = %d, want %d", tt.pairCount, got, tt.want)
+		got, parallel := dirCompareWorkers(tt.pairCount)
+		if got != tt.want || parallel != tt.wantParallel {
+			t.Errorf("dirCompareWorkers(%d) = (%d, %t), want (%d, %t)",
+				tt.pairCount, got, parallel, tt.want, tt.wantParallel)
 		}
 	}
 
+	// One usable CPU: plenty of pairs, but still nothing to gain.
 	withGOMAXPROCS(t, 1)
-	if got := dirWorkerCount(100); got != 1 {
-		t.Errorf("with GOMAXPROCS=1, dirWorkerCount(100) = %d, want 1 (streaming path)", got)
+	if got, parallel := dirCompareWorkers(100); got != 1 || parallel {
+		t.Errorf("with GOMAXPROCS=1, dirCompareWorkers(100) = (%d, %t), want (1, false)", got, parallel)
 	}
 }
 
 // TestRunDirectory_SinglePairUsesStreamingPath confirms a one-pair run still
-// works when workers < 2 short-circuits the parallel path.
+// works when dirCompareWorkers sends it down the streaming path.
 func TestRunDirectory_SinglePairUsesStreamingPath(t *testing.T) {
 	// GOMAXPROCS is high, so only the pair-count cap can force streaming here.
 	withGOMAXPROCS(t, testWorkers)
 
-	if got := dirWorkerCount(1); got >= 2 {
-		t.Fatalf("dirWorkerCount(1) = %d, expected < 2 so streaming is used", got)
+	if _, parallel := dirCompareWorkers(1); parallel {
+		t.Fatal("expected a single pair to take the streaming path")
 	}
 
 	stdout, _, code := runDirectoryCapture(t, "detailed", map[string][2][]byte{

--- a/pkg/diffyml/cli/flag_metadata.go
+++ b/pkg/diffyml/cli/flag_metadata.go
@@ -78,6 +78,7 @@ func FlagDocs() []FlagDoc {
 
 		// Configuration
 		{Long: "config", Type: "string", Default: ".diffyml.yml", Category: "Configuration", Usage: "path to config file"},
+		{Long: "jobs", Type: "int", Default: "0", Category: "Configuration", Usage: "file pairs compared in parallel in directory mode (0 = one per CPU, 1 = sequential, lowest memory)"},
 
 		// Other
 		{Long: "set-exit-code", Short: "s", Type: "bool", Category: "Other", Usage: "set program exit code based on differences"},

--- a/pkg/diffyml/cli/flag_metadata.go
+++ b/pkg/diffyml/cli/flag_metadata.go
@@ -82,5 +82,6 @@ func FlagDocs() []FlagDoc {
 		// Other
 		{Long: "set-exit-code", Short: "s", Type: "bool", Category: "Other", Usage: "set program exit code based on differences"},
 		{Long: "help", Short: "h", Type: "bool", Category: "Other", Usage: "show help"},
+		{Long: "version", Short: "V", Type: "bool", Category: "Other", Usage: "show version information"},
 	}
 }


### PR DESCRIPTION
## What

Two independent changes, one commit each:

1. **`fix:`** `-h`/`-V` were matched inside flag *values*, so a string-valued flag given one of those as its value printed usage instead of running the comparison.
2. **`perf:`** Directory mode compared one file pair at a time; the compare phase now runs across `GOMAXPROCS` workers (1.8x on 10 cores).

## Why

**The flag bug is user-visible.** `main` scanned every element of `os.Args` for `-h`/`--help`/`-V`/`--version` before parsing, and the scan could not tell a flag name from a flag value:

```
$ diffyml a.yaml b.yaml --mask-placeholder -h
diffyml - A diff tool for YAML files       # expected: a diff, masked with "-h"
```

Every string-valued flag was affected — `--mask-placeholder`, `--filter`, `--chroot`, `--summary-model`.

**Directory mode left cores idle.** Comparing two directories is embarrassingly parallel, but there was no parallelism anywhere in production code. For a tool whose headline claim is being the fastest structural YAML diff at scale, this was the clearest gap.

## How

**Flag fix.** Register `-V`/`--version` as a real flag beside the already-existing `-h`/`--help`, then short-circuit in `ParseArgs` once either is set. The pre-scan only existed because `ParseArgs` rejects a bare `--help` for missing file arguments; the short-circuit runs before that check *and* before config-file loading, so help/version keep working with no arguments and with a broken config file. The usage text already advertised `-V, --version` — it is now backed by an actual flag. `main()` is split into a testable `run(args, stdout, stderr) int`.

**Parallelism.** Compare/mask/filter runs on `GOMAXPROCS` workers, each writing only to its own result slot; formatting and writing stay on the calling goroutine and replay in pair order, so output ordering and the color/terminal state are untouched. Sharing the option structs is safe — `Compare`, `MaskDifferences` and `FilterDiffsWithRegexp` all treat their options as immutable and compile regexes per call, and the package-level values they read are immutable lookup tables.

**Trade-off worth calling out.** Buffering results to replay them in order costs memory proportional to total diffs. My first version buffered unconditionally and made the single-core case **8.6% slower** — a real regression for CPU-limited CI containers. Caught it while benchmarking, so when the worker count drops below 2 (single pair, or single CPU) the original streaming path runs and only one pair's diffs are live at a time.

Measured on 3000 differing manifests, `-o detailed`: **79 MB peak RSS parallel against 18 MB sequential**, for 0.51 s against 0.96 s. Structured formatters and `--summary` already held everything, so the growth only affects the streaming formatters. Since `GOMAXPROCS` is container-aware but nothing derives a worker count from a *memory* limit, review asked for an escape hatch and this PR now has one: **`--jobs`** (`0` = one per CPU, `1` = streaming path, any positive value honored as given, capped by the pair count; also a `jobs` config-file key). Output is byte-identical at every setting. Documented under [CI Integration → Parallelism and memory](docs/content/docs/ci.md).

Time-to-first-byte also grows: the first pair is only emitted once the whole compare phase finishes (0.15 s of the 0.51 s run above). Matters most for `-o brief` and for piping into `head`; `--jobs 1` restores incremental output.

300 manifests / 2.3 MB, mean of 15 runs on 10 cores:

| | before | after |
|---|---|---|
| all cores | 177.5 ms | **98.5 ms** (1.8x) |
| `GOMAXPROCS=1` | 209.8 ms | 210.3 ms (unchanged) |

Scaling plateaus near 4 cores, where the workload becomes IO/memory-bandwidth bound. `GOMAXPROCS` is container-aware, so worker count respects CI CPU limits.

## Checklist

- [x] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
- [x] `make ci` passes locally
- [x] New/changed behavior covered by tests
- [x] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
- [x] No new dependencies (or justified)

## Notes for reviewers

**One intentional behavior change beyond the bug fix.** A mistyped flag written *before* the file arguments no longer falls through to the help text. Because the pre-scan ran before any parsing, `diffyml --typo --help` used to print usage and exit 0, silently swallowing the typo; parsing now happens first, so it reports `Error: flag provided but not defined: -typo` and exits 255. Anything scripted around `--help` succeeding next to an invalid flag would change behavior, which seems very unlikely to be relied on deliberately.

**Scope correction (raised in review).** That only holds when the bad flag precedes the positional arguments. `reorderArgs` parks an unrecognized flag in the positional list so `fs.Parse` reports it, but `flag.Parse` stops at the first non-flag argument — so with file paths ahead of it, the typo lands in `fs.Args()[2:]` and is never looked at:

```
$ diffyml --typo a.yaml b.yaml         → Error: flag provided but not defined: -typo   (255)
$ diffyml a.yaml b.yaml --typo --help  → prints help, exit 0
$ diffyml a.yaml b.yaml --typo         → normal diff, typo silently ignored, exit 0
```

That is older than this PR and unchanged by it, so it is not a regression here — but it does mean the claim above is narrower than first written. Filed as #211 with a suggested fix and the `--`/kubectl/`GIT_EXTERNAL_DIFF` cases that need care.

Two follow-ups came out of that, both in `fix: report flag errors once, and point at --help`:

- The `flag` package writes its own error and then dumps its generated flag listing to the FlagSet's output, so a bad flag printed the error twice followed by a second usage text competing with `Usage()`. The FlagSet output is now discarded, leaving `main` as the only thing that reports the failure. Pre-existing for any bad flag, not new to this PR.
- Since a typo no longer reaches the help text, the `ParseArgs` error path now prints `Run 'diffyml --help' for usage.` so the user still has a next step. Validation errors such as `-o nope` are self-describing (they list the valid values) and are left alone.

**Output is byte-identical.** Verified against a build of the previous commit across all eight output formats, on stdout *and* stderr, at both `GOMAXPROCS=1` and `GOMAXPROCS=10`. Also checked deterministic across 20 consecutive runs.

**The ordering tests were validated by sabotage.** I temporarily changed the implementation to emit in completion order rather than pair order and confirmed all three ordering tests fail; they are not passing vacuously.

**Coverage:** total 98.2% → 98.5%; all new code at 100%. Main package rises 6.7% → 72.7% now that `run()` is testable without `os.Exit`.

**Two small things reviewers may want to weigh in on:**

- The PR title uses `fix:` because `pr-title.yml` does not accept `perf:`, though `cliff.toml` defines a `perf` changelog group. The second commit is `perf:`, so the changelog grouping is right even though the PR title cannot say so.
- Pre-existing and untouched: `make check-doc` reports 11 undocumented exported symbols (`NeatOptions`, `MaskDifferences`, `FilterReport`, …). It fails identically on `main`, and `check-doc` is not part of the `ci` target.

## Review follow-ups (added after the initial review)

| Commit | What |
|---|---|
| `refactor: build main's RunConfig from NewRunConfig` | `main` built a bare `&cli.RunConfig{Stdout, Stderr}` literal, so a future field with a non-zero default would be zero in the binary but set in every test using `NewRunConfig()`. |
| `feat: add --jobs to bound directory-mode parallelism` | The memory escape hatch described above, plus config-file key, validation (negative is an error), usage/reference/config docs, and tests asserting every `--jobs` setting matches the sequential path byte for byte. |
| `test: exercise the parallel path with the shared option structs` | The equivalence tests all ran with default options, so nothing covered the option structs the workers share — which is what the safety argument rests on. Now covered with entity/rename detection, Secret masking, `mask-path-regexp`, `--neat` and include/exclude regexes all active, under `-race`. |
| `doc: stop listing --version twice in the CLI reference` | Adding `version` to `FlagDocs` made the generated reference list it under **Other** *and* in the hand-written Version trailer, whose prose was now wrong (`--version` is no longer "handled in `main.go` before flag parsing"). `make docs-check` passed because it only compares generator output to the file. |

Also filed: #211 (unknown flags after the positional arguments are silently ignored).
