### PR TITLE
fix: tighten prompt parsing and CI quality gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 - [ ] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
 - [ ] `make ci` passes locally
 - [ ] New/changed behavior covered by tests
-- [ ] Aggregate core + CLI coverage threshold met (98%)
+- [ ] Aggregate core + CLI coverage threshold met (99%)
 - [ ] No new dependencies (or justified)
 
 ## Notes for reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 - [ ] PR title follows convention (`feat:`, `bug:`, `fix:`, `doc:`, `chore:`, `test:`)
 - [ ] `make ci` passes locally
 - [ ] New/changed behavior covered by tests
-- [ ] Coverage thresholds met (parser 100%, ordered_map 100%, kubernetes 95%)
+- [ ] Aggregate core + CLI coverage threshold met (98%)
 - [ ] No new dependencies (or justified)
 
 ## Notes for reviewers

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,6 +31,8 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+              - 'testdata/perf/**'
+              - '.github/workflows/benchmark.yml'
 
   benchmark:
     needs: changes

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      lint: ${{ steps.filter.outputs.lint }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -34,6 +35,13 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+              - '.github/workflows/security.yml'
+            lint:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.golangci.yml'
+              - '.github/workflows/security.yml'
             workflows:
               - '.github/workflows/**'
 
@@ -72,7 +80,7 @@ jobs:
 
   golangci-lint:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || github.event_name == 'schedule'
+    if: needs.changes.outputs.lint == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,16 @@ jobs:
               - '**/*.go'
               - 'go.mod'
               - 'go.sum'
+              - 'testdata/**'
+              - 'Makefile'
+              - '.github/workflows/test.yml'
             docker:
               - 'Dockerfile*'
+              - '.github/workflows/test.yml'
             packaging:
               - '.goreleaser.yaml'
               - 'Makefile'
+              - '.github/workflows/test.yml'
 
   hadolint:
     needs: changes
@@ -136,7 +141,7 @@ jobs:
           go-version: "1.26.5"
 
       - name: Run tests with coverage
-        run: go test ./pkg/diffyml/ -coverprofile=coverage.out
+        run: go test ./pkg/diffyml/... -coverprofile=coverage.out
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
@@ -172,7 +177,7 @@ jobs:
             printf "%-20s %7s%% %9s%% %s\n" "$file" "$actual" "$required" "$status"
           }
 
-          check_threshold "TOTAL" "$TOTAL_COV" "99.0"
+          check_threshold "TOTAL" "$TOTAL_COV" "98.0"
 
           echo ""
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,7 +177,7 @@ jobs:
             printf "%-20s %7s%% %9s%% %s\n" "$file" "$actual" "$required" "$status"
           }
 
-          check_threshold "TOTAL" "$TOTAL_COV" "98.0"
+          check_threshold "TOTAL" "$TOTAL_COV" "99.0"
 
           echo ""
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ check-coverage:
 		fi; \
 		printf "%-20s %7s%% %9s%% %s\n" "$$file" "$$actual" "$$required" "$$status"; \
 	}; \
-	check_threshold "TOTAL" "$$TOTAL_COV" "98.0"; \
+	check_threshold "TOTAL" "$$TOTAL_COV" "99.0"; \
 	echo ""; \
 	if [ "$$FAIL" -eq 1 ]; then \
 		echo "Coverage threshold check FAILED"; \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ coverage:
 	go tool cover -html=coverage.out
 
 check-coverage:
-	@go test ./pkg/diffyml/ -coverprofile=coverage.out
+	@go test ./pkg/diffyml/... -coverprofile=coverage.out
 	@COVER_OUTPUT=$$(go tool cover -func=coverage.out); \
 	TOTAL_COV=$$(echo "$$COVER_OUTPUT" | grep '^total:' | awk '{print $$NF}' | tr -d '%'); \
 	echo ""; \
@@ -27,7 +27,7 @@ check-coverage:
 		fi; \
 		printf "%-20s %7s%% %9s%% %s\n" "$$file" "$$actual" "$$required" "$$status"; \
 	}; \
-	check_threshold "TOTAL" "$$TOTAL_COV" "99.0"; \
+	check_threshold "TOTAL" "$$TOTAL_COV" "98.0"; \
 	echo ""; \
 	if [ "$$FAIL" -eq 1 ]; then \
 		echo "Coverage threshold check FAILED"; \

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ See the [package documentation](https://pkg.go.dev/github.com/szhekpisov/diffyml
   [misspell](https://github.com/client9/misspell),
   [staticcheck](https://staticcheck.dev/) (all checks except style conventions)
 
-**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 98%+ aggregate code coverage across the core and CLI packages, [mutation testing](https://github.com/szhekpisov/gomutants) gated per-PR (no LIVED mutant on changed lines) with an 85% post-merge efficacy floor. CI enforces a 98% aggregate coverage floor.
+**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 99%+ aggregate code coverage across the core and CLI packages, [mutation testing](https://github.com/szhekpisov/gomutants) gated per-PR (no LIVED mutant on changed lines) with an 85% post-merge efficacy floor. CI enforces a 99% aggregate coverage floor.
 
 **Reporting vulnerabilities.** See [SECURITY.md](SECURITY.md) — preferred path is a [private GitHub Security Advisory](https://github.com/szhekpisov/diffyml/security/advisories/new).
 
@@ -717,7 +717,7 @@ pre-commit install
 |------|---------------|
 | `gofmt` | Code formatting |
 | `go vet` | Static analysis |
-| `check-coverage` | Aggregate core + CLI coverage threshold (98% overall) |
+| `check-coverage` | Aggregate core + CLI coverage threshold (99% overall) |
 | `govulncheck` | Known vulnerabilities |
 | `golangci-lint` | 7 linters (errcheck, gocritic, gosec, govet, ineffassign, misspell, staticcheck) |
 

--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ See the [package documentation](https://pkg.go.dev/github.com/szhekpisov/diffyml
   [misspell](https://github.com/client9/misspell),
   [staticcheck](https://staticcheck.dev/) (all checks except style conventions)
 
-**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 99.4% code coverage, [mutation testing](https://github.com/szhekpisov/gomutants) gated per-PR (no LIVED mutant on changed lines) with an 85.65% post-merge efficacy floor. CI enforces a 99% coverage floor.
+**Test quality.** 1,500+ tests (unit, e2e, fuzz, property-based), 98%+ aggregate code coverage across the core and CLI packages, [mutation testing](https://github.com/szhekpisov/gomutants) gated per-PR (no LIVED mutant on changed lines) with an 85% post-merge efficacy floor. CI enforces a 98% aggregate coverage floor.
 
 **Reporting vulnerabilities.** See [SECURITY.md](SECURITY.md) — preferred path is a [private GitHub Security Advisory](https://github.com/szhekpisov/diffyml/security/advisories/new).
 
@@ -717,7 +717,7 @@ pre-commit install
 |------|---------------|
 | `gofmt` | Code formatting |
 | `go vet` | Static analysis |
-| `check-coverage` | Coverage threshold (99% overall) |
+| `check-coverage` | Aggregate core + CLI coverage threshold (98% overall) |
 | `govulncheck` | Known vulnerabilities |
 | `golangci-lint` | 7 linters (errcheck, gocritic, gosec, govet, ineffassign, misspell, staticcheck) |
 

--- a/pkg/diffyml/cli/cli_run_test.go
+++ b/pkg/diffyml/cli/cli_run_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/szhekpisov/diffyml/pkg/diffyml"
 )
 
 // Tests for main execution flow (Task 5.4)
@@ -21,6 +24,48 @@ func TestRunConfig_Defaults(t *testing.T) {
 	if rc.Stderr == nil {
 		t.Error("expected Stderr to be initialized")
 	}
+}
+
+func TestWriteNeatExplain(t *testing.T) {
+	cfg := NewCLIConfig()
+	patterns := diffyml.NeatPatterns(cfg.ToNeatOptions())
+	if len(patterns) < 2 {
+		t.Fatalf("need at least two neat patterns, got %d", len(patterns))
+	}
+
+	t.Run("no patterns fired", func(t *testing.T) {
+		report := &diffyml.FilterReport{ExcludeHits: make([]int, len(patterns))}
+		var output strings.Builder
+
+		writeNeatExplain(&output, cfg, report)
+
+		if got := output.String(); got != "neat: no patterns fired\n" {
+			t.Errorf("writeNeatExplain() = %q", got)
+		}
+	})
+
+	t.Run("singular and plural hits", func(t *testing.T) {
+		hits := make([]int, len(patterns))
+		hits[0] = 1
+		hits[1] = 2
+		report := &diffyml.FilterReport{ExcludeHits: hits}
+		var output strings.Builder
+
+		writeNeatExplain(&output, cfg, report)
+
+		got := output.String()
+		if !strings.Contains(got, "neat: filtered 3 diffs across 2 patterns") {
+			t.Errorf("missing summary in %q", got)
+		}
+		wantFirst := fmt.Sprintf("[%s] %s (1 hit)", patterns[0].Profile, patterns[0].Label)
+		if !strings.Contains(got, wantFirst) {
+			t.Errorf("missing singular hit entry %q in %q", wantFirst, got)
+		}
+		wantSecond := fmt.Sprintf("[%s] %s (2 hits)", patterns[1].Profile, patterns[1].Label)
+		if !strings.Contains(got, wantSecond) {
+			t.Errorf("missing plural hit entry %q in %q", wantSecond, got)
+		}
+	})
 }
 
 func TestRun_MissingFromFile(t *testing.T) {

--- a/pkg/diffyml/cli/cli_validation_test.go
+++ b/pkg/diffyml/cli/cli_validation_test.go
@@ -110,6 +110,21 @@ func TestCLIConfig_Validate_InvalidExcludeRegexp(t *testing.T) {
 	}
 }
 
+func TestCLIConfig_Validate_InvalidMaskPathRegexp(t *testing.T) {
+	cfg := NewCLIConfig()
+	cfg.FromFile = "from.yaml"
+	cfg.ToFile = "to.yaml"
+	cfg.MaskPathRegexp = []string{`[invalid`}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for invalid mask path regex")
+	}
+	if !strings.Contains(err.Error(), "mask-path-regexp") {
+		t.Errorf("error should mention mask-path-regexp, got %q", err)
+	}
+}
+
 func TestCLIConfig_Validate_NeatStripPath_RequiresNeat(t *testing.T) {
 	cfg := NewCLIConfig()
 	cfg.FromFile = "from.yaml"

--- a/pkg/diffyml/cli/color_config_test.go
+++ b/pkg/diffyml/cli/color_config_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -199,6 +200,31 @@ func TestLoadColorPalette_InvalidColor(t *testing.T) {
 	_, err := loadColorPalette(fc)
 	if err == nil {
 		t.Error("expected error for invalid color")
+	}
+}
+
+func TestLoadColorPalette_InvalidRemainingColorFields(t *testing.T) {
+	for _, field := range []string{"removed", "context", "doc-name"} {
+		t.Run(field, func(t *testing.T) {
+			invalid := "notacolor"
+			colors := &ColorOverrides{}
+			switch field {
+			case "removed":
+				colors.Removed = &invalid
+			case "context":
+				colors.Context = &invalid
+			case "doc-name":
+				colors.DocName = &invalid
+			}
+
+			_, err := loadColorPalette(&FileConfig{Colors: colors})
+			if err == nil {
+				t.Fatalf("expected error for invalid %s color", field)
+			}
+			if !strings.Contains(err.Error(), field) {
+				t.Errorf("error %q should identify %s", err, field)
+			}
+		})
 	}
 }
 

--- a/pkg/diffyml/cli/config_test.go
+++ b/pkg/diffyml/cli/config_test.go
@@ -470,6 +470,70 @@ func TestApplyFileConfig_BoolFields(t *testing.T) {
 	}
 }
 
+func TestApplyFileConfig_RemainingScalarAndMaskFields(t *testing.T) {
+	cfg := NewCLIConfig()
+	enabled := true
+	trueColor := "always"
+	maskPlaceholder := "[MASKED]"
+	fc := &FileConfig{
+		TrueColor:               &trueColor,
+		IgnoreWhitespaceChanges: &enabled,
+		FormatStrings:           &enabled,
+		IgnoreValueChanges:      &enabled,
+		IgnoreApiVersion:        &enabled,
+		NoCertInspection:        &enabled,
+		MaskSecrets:             &enabled,
+		MaskPaths:               []string{"data.password"},
+		MaskPathRegexp:          []string{`^stringData\.`},
+		MaskPlaceholder:         &maskPlaceholder,
+		OmitHeader:              &enabled,
+		UseGoPatchStyle:         &enabled,
+		SetExitCode:             &enabled,
+	}
+
+	cfg.applyFileConfig(fc, map[string]bool{})
+
+	if cfg.TrueColor != trueColor {
+		t.Errorf("TrueColor = %q, want %q", cfg.TrueColor, trueColor)
+	}
+	if !cfg.IgnoreWhitespaceChanges {
+		t.Error("expected IgnoreWhitespaceChanges=true")
+	}
+	if !cfg.FormatStrings {
+		t.Error("expected FormatStrings=true")
+	}
+	if !cfg.IgnoreValueChanges {
+		t.Error("expected IgnoreValueChanges=true")
+	}
+	if !cfg.IgnoreApiVersion {
+		t.Error("expected IgnoreApiVersion=true")
+	}
+	if !cfg.NoCertInspection {
+		t.Error("expected NoCertInspection=true")
+	}
+	if !cfg.MaskSecrets {
+		t.Error("expected MaskSecrets=true")
+	}
+	if len(cfg.MaskPaths) != 1 || cfg.MaskPaths[0] != "data.password" {
+		t.Errorf("MaskPaths = %v, want [data.password]", cfg.MaskPaths)
+	}
+	if len(cfg.MaskPathRegexp) != 1 || cfg.MaskPathRegexp[0] != `^stringData\.` {
+		t.Errorf("MaskPathRegexp = %v, want [^stringData\\.]", cfg.MaskPathRegexp)
+	}
+	if cfg.MaskPlaceholder != maskPlaceholder {
+		t.Errorf("MaskPlaceholder = %q, want %q", cfg.MaskPlaceholder, maskPlaceholder)
+	}
+	if !cfg.OmitHeader {
+		t.Error("expected OmitHeader=true")
+	}
+	if !cfg.UseGoPatchStyle {
+		t.Error("expected UseGoPatchStyle=true")
+	}
+	if !cfg.SetExitCode {
+		t.Error("expected SetExitCode=true")
+	}
+}
+
 func TestApplyFileConfig_BoolDefaultTrue_ConfigSetsFalse(t *testing.T) {
 	cfg := NewCLIConfig()
 	if !cfg.DetectKubernetes {

--- a/pkg/diffyml/cli/summarizer.go
+++ b/pkg/diffyml/cli/summarizer.go
@@ -218,7 +218,18 @@ func remainingPromptItems(groups []diffyml.DiffGroup, groupIndex, diffIndex int)
 }
 
 func truncationMarker(remainingChanges, remainingFiles int) string {
-	return fmt.Sprintf("\n... and %d more changes across %d files (truncated)\n", remainingChanges, remainingFiles)
+	changeLabel := "changes"
+	if remainingChanges == 1 {
+		changeLabel = "change"
+	}
+	fileLabel := "files"
+	if remainingFiles == 1 {
+		fileLabel = "file"
+	}
+	return fmt.Sprintf(
+		"\n... and %d more %s across %d %s (truncated)\n",
+		remainingChanges, changeLabel, remainingFiles, fileLabel,
+	)
 }
 
 // buildTruncatedPrompt rebuilds an oversized prompt while reserving space for

--- a/pkg/diffyml/cli/summarizer.go
+++ b/pkg/diffyml/cli/summarizer.go
@@ -200,41 +200,101 @@ func diffTypeLabel(dt diffyml.DiffType) string {
 	}
 }
 
-// buildPrompt serializes DiffGroups into structured text for the API.
-func buildPrompt(groups []diffyml.DiffGroup) string {
+// remainingPromptItems counts changes and files that have not yet been written.
+// diffIndex is the first unwritten difference in groups[groupIndex].
+func remainingPromptItems(groups []diffyml.DiffGroup, groupIndex, diffIndex int) (changes, files int) {
+	for i := groupIndex; i < len(groups); i++ {
+		start := 0
+		if i == groupIndex {
+			start = diffIndex
+		}
+		if start >= len(groups[i].Diffs) {
+			continue
+		}
+		changes += len(groups[i].Diffs) - start
+		files++
+	}
+	return changes, files
+}
+
+func truncationMarker(remainingChanges, remainingFiles int) string {
+	return fmt.Sprintf("\n... and %d more changes across %d files (truncated)\n", remainingChanges, remainingFiles)
+}
+
+// buildTruncatedPrompt rebuilds an oversized prompt while reserving space for
+// an exact truncation marker. Only complete headers and differences are
+// written, so the marker's remaining-change count always matches the content.
+func buildTruncatedPrompt(groups []diffyml.DiffGroup) string {
 	var sb strings.Builder
-	totalLen := 0
-	groupsWritten := 0
-	totalGroups := len(groups)
-	totalRemainingDiffs := 0
+	remainingChanges, remainingFiles := remainingPromptItems(groups, 0, 0)
 
 	for _, group := range groups {
-		// Serialize this group into a temporary buffer
-		var groupBuf strings.Builder
-		fmt.Fprintf(&groupBuf, "File: %s\n", group.FilePath)
+		marker := truncationMarker(remainingChanges, remainingFiles)
+		header := fmt.Sprintf("File: %s\n", group.FilePath)
+		if sb.Len()+len(header)+len(marker) > maxPromptLen {
+			return sb.String() + marker
+		}
+		sb.WriteString(header)
+
+		for diffIndex, diff := range group.Diffs {
+			from := diffyml.SerializeValue(diff.From)
+			to := diffyml.SerializeValue(diff.To)
+			line := fmt.Sprintf("- [%s] %s: %q → %q\n", diffTypeLabel(diff.Type), diff.Path, from, to)
+
+			changesAfter := remainingChanges - 1
+			filesAfter := remainingFiles
+			if diffIndex == len(group.Diffs)-1 {
+				filesAfter--
+			}
+
+			reserved := ""
+			if changesAfter > 0 {
+				reserved = truncationMarker(changesAfter, filesAfter)
+			}
+			if sb.Len()+len(line)+len(reserved) > maxPromptLen {
+				return sb.String() + marker
+			}
+
+			sb.WriteString(line)
+			remainingChanges = changesAfter
+			remainingFiles = filesAfter
+			marker = reserved
+		}
+
+		if sb.Len()+1+len(marker) <= maxPromptLen {
+			sb.WriteByte('\n')
+		}
+	}
+
+	return sb.String()
+}
+
+// buildPrompt serializes DiffGroups into structured text for the API while
+// keeping the complete request prompt within maxPromptLen bytes. It writes one
+// difference at a time so a single large file cannot bypass the limit.
+func buildPrompt(groups []diffyml.DiffGroup) string {
+	var sb strings.Builder
+
+	for _, group := range groups {
+		header := fmt.Sprintf("File: %s\n", group.FilePath)
+		if sb.Len()+len(header) > maxPromptLen {
+			return buildTruncatedPrompt(groups)
+		}
+		sb.WriteString(header)
+
 		for _, diff := range group.Diffs {
 			from := diffyml.SerializeValue(diff.From)
 			to := diffyml.SerializeValue(diff.To)
-			fmt.Fprintf(&groupBuf, "- [%s] %s: %q → %q\n", diffTypeLabel(diff.Type), diff.Path, from, to)
-		}
-		groupBuf.WriteString("\n")
-
-		groupText := groupBuf.String()
-
-		// Check truncation before adding
-		if totalLen+len(groupText) > maxPromptLen && groupsWritten > 0 {
-			// Count remaining diffs
-			for _, g := range groups[groupsWritten:] {
-				totalRemainingDiffs += len(g.Diffs)
+			line := fmt.Sprintf("- [%s] %s: %q → %q\n", diffTypeLabel(diff.Type), diff.Path, from, to)
+			if sb.Len()+len(line) > maxPromptLen {
+				return buildTruncatedPrompt(groups)
 			}
-			remainingFiles := totalGroups - groupsWritten
-			fmt.Fprintf(&sb, "... and %d more changes across %d more files (truncated)\n", totalRemainingDiffs, remainingFiles)
-			break
+			sb.WriteString(line)
 		}
 
-		sb.WriteString(groupText)
-		totalLen += len(groupText)
-		groupsWritten++
+		if sb.Len() < maxPromptLen {
+			sb.WriteByte('\n')
+		}
 	}
 
 	return sb.String()

--- a/pkg/diffyml/cli/summarizer_test.go
+++ b/pkg/diffyml/cli/summarizer_test.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/szhekpisov/diffyml/pkg/diffyml"
 )
@@ -96,6 +98,9 @@ func TestBuildPrompt_Truncation(t *testing.T) {
 	got := buildPrompt(groups)
 	if !strings.Contains(got, "truncated") {
 		t.Errorf("buildPrompt should truncate large input, got length: %d", len(got))
+	}
+	if len(got) > maxPromptLen {
+		t.Errorf("buildPrompt length = %d, want <= %d", len(got), maxPromptLen)
 	}
 }
 
@@ -378,8 +383,6 @@ func TestSummarize_ServerError500_IncludesMessage(t *testing.T) {
 }
 
 func TestBuildPrompt_SingleOversizedGroup(t *testing.T) {
-	// summarizer.go:215 — single oversized group should still be included
-	// (groupsWritten > 0 condition means first group is never truncated)
 	var diffs []diffyml.Difference
 	for i := 0; i < 500; i++ {
 		diffs = append(diffs, diffyml.Difference{
@@ -396,13 +399,17 @@ func TestBuildPrompt_SingleOversizedGroup(t *testing.T) {
 
 	got := buildPrompt(groups)
 
-	// The single group must be included even if it exceeds maxPromptLen
 	if !strings.Contains(got, "File: single-big.yaml") {
-		t.Error("single oversized group should still be included in prompt")
+		t.Error("single oversized group should retain its file header")
 	}
-	// Should NOT contain truncation message since it's the only group
-	if strings.Contains(got, "truncated") {
-		t.Error("single oversized group should not trigger truncation")
+	if !strings.Contains(got, "truncated") {
+		t.Error("single oversized group should be truncated")
+	}
+	if len(got) > maxPromptLen {
+		t.Errorf("buildPrompt length = %d, want <= %d", len(got), maxPromptLen)
+	}
+	if !utf8.ValidString(got) {
+		t.Error("truncated prompt must remain valid UTF-8")
 	}
 }
 
@@ -427,20 +434,22 @@ func TestBuildPrompt_TruncationRemainingCount(t *testing.T) {
 
 	got := buildPrompt(groups)
 
-	// file1 should be included (first group always is)
+	// The first file should be represented before truncation.
 	if !strings.Contains(got, "File: file1.yaml") {
-		t.Error("first group should always be included")
+		t.Error("first group should be present")
 	}
 
-	// If truncated, remaining count should be correct (3 files with correct diff counts)
-	if strings.Contains(got, "truncated") {
-		// Remaining should be 3 files (file2, file3, file4) with 3 total changes
-		if !strings.Contains(got, "3 more files") {
-			t.Errorf("truncation message should say '3 more files', got: %s", got)
-		}
-		if !strings.Contains(got, "3 more changes") {
-			t.Errorf("truncation message should say '3 more changes', got: %s", got)
-		}
+	if !strings.Contains(got, "truncated") {
+		t.Fatal("expected prompt to be truncated")
+	}
+	writtenChanges := strings.Count(got, "\n- [")
+	remainingChanges := len(bigDiffs) + 3 - writtenChanges
+	expectedMarker := fmt.Sprintf("%d more changes across 4 files", remainingChanges)
+	if !strings.Contains(got, expectedMarker) {
+		t.Errorf("truncation marker should contain %q, got: %s", expectedMarker, got)
+	}
+	if len(got) > maxPromptLen {
+		t.Errorf("buildPrompt length = %d, want <= %d", len(got), maxPromptLen)
 	}
 }
 
@@ -508,7 +517,10 @@ func TestBuildPrompt_ExactBoundary(t *testing.T) {
 }
 
 func TestBuildPrompt_OneByteOverBoundary(t *testing.T) {
-	// Companion test: verify that one byte over the boundary DOES truncate.
+	// Companion test: verify that one byte of content over the boundary DOES
+	// truncate. The serializer may omit the optional final blank line, so add
+	// two bytes to the complete representation to put the diff line itself one
+	// byte over the limit.
 	singleDiff := diffyml.Difference{
 		Path: diffyml.DiffPath{"test", "path"},
 		Type: diffyml.DiffModified,
@@ -522,7 +534,7 @@ func TestBuildPrompt_OneByteOverBoundary(t *testing.T) {
 	singlePrompt := buildPrompt([]diffyml.DiffGroup{testGroup})
 	singleLen := len(singlePrompt)
 
-	remaining := maxPromptLen - singleLen + 1 // one byte over
+	remaining := maxPromptLen - singleLen + 2
 	if remaining <= 0 {
 		t.Skip("single group already exceeds maxPromptLen")
 	}
@@ -544,15 +556,14 @@ func TestBuildPrompt_OneByteOverBoundary(t *testing.T) {
 	groups := []diffyml.DiffGroup{testGroup, group2}
 	got := buildPrompt(groups)
 
-	// Second group should be truncated since total > maxPromptLen
 	if !strings.Contains(got, "File: test.yaml") {
-		t.Error("first group should always be present")
-	}
-	if strings.Contains(got, "File: pad.yaml") {
-		t.Error("second group should be truncated when total exceeds maxPromptLen")
+		t.Error("first group should be present")
 	}
 	if !strings.Contains(got, "truncated") {
 		t.Error("should truncate when total exceeds maxPromptLen by 1")
+	}
+	if len(got) > maxPromptLen {
+		t.Errorf("buildPrompt length = %d, want <= %d", len(got), maxPromptLen)
 	}
 }
 

--- a/pkg/diffyml/cli/summarizer_test.go
+++ b/pkg/diffyml/cli/summarizer_test.go
@@ -453,6 +453,60 @@ func TestBuildPrompt_TruncationRemainingCount(t *testing.T) {
 	}
 }
 
+func TestRemainingPromptItems_SkipsEmptyAndConsumedGroups(t *testing.T) {
+	groups := []diffyml.DiffGroup{
+		{FilePath: "empty.yaml"},
+		{
+			FilePath: "changes.yaml",
+			Diffs: []diffyml.Difference{
+				{Path: diffyml.DiffPath{"a"}, Type: diffyml.DiffAdded, To: 1},
+				{Path: diffyml.DiffPath{"b"}, Type: diffyml.DiffAdded, To: 2},
+			},
+		},
+	}
+
+	changes, files := remainingPromptItems(groups, 0, 0)
+	if changes != 2 || files != 1 {
+		t.Errorf("remainingPromptItems() = (%d, %d), want (2, 1)", changes, files)
+	}
+
+	changes, files = remainingPromptItems(groups, 1, len(groups[1].Diffs))
+	if changes != 0 || files != 0 {
+		t.Errorf("consumed group = (%d, %d), want (0, 0)", changes, files)
+	}
+}
+
+func TestBuildPrompt_HeaderExceedsLimit(t *testing.T) {
+	groups := []diffyml.DiffGroup{{
+		FilePath: strings.Repeat("x", maxPromptLen),
+		Diffs:    []diffyml.Difference{{Path: diffyml.DiffPath{"a"}, Type: diffyml.DiffAdded, To: 1}},
+	}}
+
+	got := buildPrompt(groups)
+	if len(got) > maxPromptLen {
+		t.Errorf("buildPrompt length = %d, want <= %d", len(got), maxPromptLen)
+	}
+	if strings.Contains(got, "File: ") {
+		t.Error("oversized file header should not be written")
+	}
+	if !strings.Contains(got, "1 more change across 1 file (truncated)") {
+		t.Errorf("expected exact truncation marker, got %q", got)
+	}
+}
+
+func TestBuildTruncatedPrompt_InputFits(t *testing.T) {
+	groups := []diffyml.DiffGroup{{
+		FilePath: "small.yaml",
+		Diffs:    []diffyml.Difference{{Path: diffyml.DiffPath{"a"}, Type: diffyml.DiffAdded, To: 1}},
+	}}
+
+	got := buildTruncatedPrompt(groups)
+	want := buildPrompt(groups)
+	if got != want {
+		t.Errorf("buildTruncatedPrompt() = %q, want %q", got, want)
+	}
+}
+
 func TestBuildPrompt_ExactBoundary(t *testing.T) {
 	// summarizer.go:215 — `> maxPromptLen` → `>= maxPromptLen`
 	// If mutated, a prompt that totals exactly maxPromptLen would be truncated.

--- a/pkg/diffyml/parser.go
+++ b/pkg/diffyml/parser.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 
 	"go.yaml.in/yaml/v3"
 )
@@ -72,13 +74,16 @@ func (p *DocumentParser) Done() bool {
 // ParseError represents a YAML parsing error with location information.
 type ParseError struct {
 	Line    int    // Line number where error occurred (1-based)
-	Column  int    // Column number where error occurred (1-based)
+	Column  int    // Column number where error occurred (1-based, or 0 when unavailable)
 	Message string // Error message
 	Err     error  // Underlying error
 }
 
 // Error implements the error interface.
 func (e *ParseError) Error() string {
+	if e.Line > 0 && e.Column > 0 {
+		return fmt.Sprintf("yaml: line %d: column %d: %s", e.Line, e.Column, e.Message)
+	}
 	if e.Line > 0 {
 		return fmt.Sprintf("yaml: line %d: %s", e.Line, e.Message)
 	}
@@ -90,20 +95,52 @@ func (e *ParseError) Unwrap() error {
 	return e.Err
 }
 
-// wrapParseError wraps a yaml parsing error with line information if available.
-func wrapParseError(err error) error {
-	// yaml.v3 includes line info in the error message
-	// Try to extract it if possible
-	var typeErr *yaml.TypeError
-	if errors.As(err, &typeErr) {
-		return &ParseError{
-			Message: typeErr.Error(),
-			Err:     err,
+// parseErrorLocation extracts the leading location emitted by yaml.v3. The
+// decoder currently reports a line for syntax errors and may omit the column.
+func parseErrorLocation(message string) (line, column int, detail string) {
+	detail = strings.TrimPrefix(message, "yaml: ")
+	if !strings.HasPrefix(detail, "line ") {
+		return 0, 0, detail
+	}
+
+	locationEnd := strings.IndexByte(detail, ':')
+	if locationEnd < 0 {
+		return 0, 0, detail
+	}
+
+	parsedLine, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(detail[:locationEnd], "line ")))
+	if err != nil || parsedLine < 1 {
+		return 0, 0, detail
+	}
+
+	remainder := strings.TrimSpace(detail[locationEnd+1:])
+	if strings.HasPrefix(remainder, "column ") {
+		columnEnd := strings.IndexByte(remainder, ':')
+		if columnEnd >= 0 {
+			parsedColumn, columnErr := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(remainder[:columnEnd], "column ")))
+			if columnErr == nil && parsedColumn > 0 {
+				return parsedLine, parsedColumn, strings.TrimSpace(remainder[columnEnd+1:])
+			}
 		}
 	}
 
-	// Return original error if we can't wrap it nicely
-	return err
+	return parsedLine, 0, remainder
+}
+
+// wrapParseError wraps every yaml parsing error in a consistent public type
+// and extracts location information when yaml.v3 provides it.
+func wrapParseError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	line, column, message := parseErrorLocation(err.Error())
+	return &ParseError{
+		Line:    line,
+		Column:  column,
+		Message: message,
+		Err:     err,
+	}
 }
 
 // parse parses YAML content into per-document *yaml.Node trees, padding the

--- a/pkg/diffyml/parser.go
+++ b/pkg/diffyml/parser.go
@@ -103,23 +103,23 @@ func parseErrorLocation(message string) (line, column int, detail string) {
 		return 0, 0, detail
 	}
 
-	locationEnd := strings.IndexByte(detail, ':')
-	if locationEnd < 0 {
+	location, remainder, found := strings.Cut(detail, ":")
+	if !found {
 		return 0, 0, detail
 	}
 
-	parsedLine, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(detail[:locationEnd], "line ")))
+	parsedLine, err := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(location, "line ")))
 	if err != nil || parsedLine < 1 {
 		return 0, 0, detail
 	}
 
-	remainder := strings.TrimSpace(detail[locationEnd+1:])
+	remainder = strings.TrimSpace(remainder)
 	if strings.HasPrefix(remainder, "column ") {
-		columnEnd := strings.IndexByte(remainder, ':')
-		if columnEnd >= 0 {
-			parsedColumn, columnErr := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(remainder[:columnEnd], "column ")))
+		columnLocation, columnDetail, columnFound := strings.Cut(remainder, ":")
+		if columnFound {
+			parsedColumn, columnErr := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(columnLocation, "column ")))
 			if columnErr == nil && parsedColumn > 0 {
-				return parsedLine, parsedColumn, strings.TrimSpace(remainder[columnEnd+1:])
+				return parsedLine, parsedColumn, strings.TrimSpace(columnDetail)
 			}
 		}
 	}

--- a/pkg/diffyml/parser_coverage_test.go
+++ b/pkg/diffyml/parser_coverage_test.go
@@ -197,4 +197,60 @@ func TestWrapParseError(t *testing.T) {
 			t.Errorf("expected error text %q, got %q", orig, got)
 		}
 	})
+
+	t.Run("malformed locations", func(t *testing.T) {
+		tests := []struct {
+			name       string
+			message    string
+			wantLine   int
+			wantColumn int
+			wantDetail string
+		}{
+			{
+				name:       "line without separator",
+				message:    "yaml: line nope",
+				wantDetail: "line nope",
+			},
+			{
+				name:       "non-numeric line",
+				message:    "yaml: line nope: bad indentation",
+				wantDetail: "line nope: bad indentation",
+			},
+			{
+				name:       "zero line",
+				message:    "yaml: line 0: bad indentation",
+				wantDetail: "line 0: bad indentation",
+			},
+			{
+				name:       "column without separator",
+				message:    "yaml: line 7: column nope",
+				wantLine:   7,
+				wantDetail: "column nope",
+			},
+			{
+				name:       "non-numeric column",
+				message:    "yaml: line 7: column nope: bad indentation",
+				wantLine:   7,
+				wantDetail: "column nope: bad indentation",
+			},
+			{
+				name:       "zero column",
+				message:    "yaml: line 7: column 0: bad indentation",
+				wantLine:   7,
+				wantDetail: "column 0: bad indentation",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				line, column, detail := parseErrorLocation(tt.message)
+				if line != tt.wantLine || column != tt.wantColumn || detail != tt.wantDetail {
+					t.Errorf(
+						"parseErrorLocation(%q) = (%d, %d, %q), want (%d, %d, %q)",
+						tt.message, line, column, detail, tt.wantLine, tt.wantColumn, tt.wantDetail,
+					)
+				}
+			})
+		}
+	})
 }

--- a/pkg/diffyml/parser_coverage_test.go
+++ b/pkg/diffyml/parser_coverage_test.go
@@ -107,7 +107,7 @@ func TestParseError_Error(t *testing.T) {
 	t.Run("with line", func(t *testing.T) {
 		pe := &ParseError{Line: 5, Column: 3, Message: "bad indent"}
 		got := pe.Error()
-		expected := "yaml: line 5: bad indent"
+		expected := "yaml: line 5: column 3: bad indent"
 		if got != expected {
 			t.Errorf("expected %q, got %q", expected, got)
 		}
@@ -148,13 +148,53 @@ func TestWrapParseError(t *testing.T) {
 		if !errors.Is(pe.Err, typeErr) {
 			t.Error("expected Err to wrap original TypeError")
 		}
+		if pe.Message != "unmarshal errors:\n  test error" {
+			t.Errorf("unexpected message: %q", pe.Message)
+		}
 	})
 
 	t.Run("other error", func(t *testing.T) {
 		orig := errors.New("some other error")
 		got := wrapParseError(orig)
+		var pe *ParseError
+		if !errors.As(got, &pe) {
+			t.Fatalf("expected *ParseError, got %T", got)
+		}
 		if !errors.Is(got, orig) {
-			t.Errorf("expected original error returned unchanged, got %v", got)
+			t.Errorf("expected wrapped original error, got %v", got)
+		}
+		if pe.Line != 0 || pe.Column != 0 || pe.Message != orig.Error() {
+			t.Errorf("unexpected ParseError fields: %#v", pe)
+		}
+	})
+
+	t.Run("line location", func(t *testing.T) {
+		orig := errors.New("yaml: line 7: bad indentation")
+		got := wrapParseError(orig)
+		var pe *ParseError
+		if !errors.As(got, &pe) {
+			t.Fatalf("expected *ParseError, got %T", got)
+		}
+		if pe.Line != 7 || pe.Column != 0 || pe.Message != "bad indentation" {
+			t.Errorf("unexpected ParseError fields: %#v", pe)
+		}
+		if got.Error() != orig.Error() {
+			t.Errorf("expected error text %q, got %q", orig, got)
+		}
+	})
+
+	t.Run("line and column location", func(t *testing.T) {
+		orig := errors.New("yaml: line 7: column 4: bad indentation")
+		got := wrapParseError(orig)
+		var pe *ParseError
+		if !errors.As(got, &pe) {
+			t.Fatalf("expected *ParseError, got %T", got)
+		}
+		if pe.Line != 7 || pe.Column != 4 || pe.Message != "bad indentation" {
+			t.Errorf("unexpected ParseError fields: %#v", pe)
+		}
+		if got.Error() != orig.Error() {
+			t.Errorf("expected error text %q, got %q", orig, got)
 		}
 	})
 }

--- a/pkg/diffyml/parser_coverage_test.go
+++ b/pkg/diffyml/parser_coverage_test.go
@@ -105,9 +105,18 @@ func TestDocumentParser(t *testing.T) {
 
 func TestParseError_Error(t *testing.T) {
 	t.Run("with line", func(t *testing.T) {
-		pe := &ParseError{Line: 5, Column: 3, Message: "bad indent"}
+		pe := &ParseError{Line: 1, Column: 1, Message: "bad indent"}
 		got := pe.Error()
-		expected := "yaml: line 5: column 3: bad indent"
+		expected := "yaml: line 1: column 1: bad indent"
+		if got != expected {
+			t.Errorf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("column without line", func(t *testing.T) {
+		pe := &ParseError{Line: 0, Column: 3, Message: "bad indent"}
+		got := pe.Error()
+		expected := "yaml: bad indent"
 		if got != expected {
 			t.Errorf("expected %q, got %q", expected, got)
 		}
@@ -184,13 +193,13 @@ func TestWrapParseError(t *testing.T) {
 	})
 
 	t.Run("line and column location", func(t *testing.T) {
-		orig := errors.New("yaml: line 7: column 4: bad indentation")
+		orig := errors.New("yaml: line 1: column 1: bad indentation")
 		got := wrapParseError(orig)
 		var pe *ParseError
 		if !errors.As(got, &pe) {
 			t.Fatalf("expected *ParseError, got %T", got)
 		}
-		if pe.Line != 7 || pe.Column != 4 || pe.Message != "bad indentation" {
+		if pe.Line != 1 || pe.Column != 1 || pe.Message != "bad indentation" {
 			t.Errorf("unexpected ParseError fields: %#v", pe)
 		}
 		if got.Error() != orig.Error() {
@@ -212,6 +221,16 @@ func TestWrapParseError(t *testing.T) {
 				wantDetail: "line nope",
 			},
 			{
+				name:       "numeric line without separator",
+				message:    "yaml: line 7",
+				wantDetail: "line 7",
+			},
+			{
+				name:       "non-location with parseable prefix",
+				message:    "yaml: 7: bad indentation",
+				wantDetail: "7: bad indentation",
+			},
+			{
 				name:       "non-numeric line",
 				message:    "yaml: line nope: bad indentation",
 				wantDetail: "line nope: bad indentation",
@@ -226,6 +245,12 @@ func TestWrapParseError(t *testing.T) {
 				message:    "yaml: line 7: column nope",
 				wantLine:   7,
 				wantDetail: "column nope",
+			},
+			{
+				name:       "numeric column without separator",
+				message:    "yaml: line 7: column 4",
+				wantLine:   7,
+				wantDetail: "column 4",
 			},
 			{
 				name:       "non-numeric column",

--- a/pkg/diffyml/parser_test.go
+++ b/pkg/diffyml/parser_test.go
@@ -281,14 +281,13 @@ valid: content
 		t.Fatal("expected error for invalid YAML")
 	}
 
-	// Check if error can be converted to ParseError
 	var pe *ParseError
-	if errors.As(err, &pe) {
-		if pe.Line == 0 {
-			t.Error("expected non-zero line number in ParseError")
-		}
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *ParseError, got %T", err)
 	}
-	// Note: yaml.v3 errors may not always be wrapped as ParseError
+	if pe.Line == 0 {
+		t.Error("expected non-zero line number in ParseError")
+	}
 }
 
 func TestParse_DocumentIndex(t *testing.T) {


### PR DESCRIPTION
## What

- enforce the 8,000-byte AI summary prompt limit for every file, including a single oversized group
- preserve complete UTF-8 records and report exact remaining change/file counts when truncating
- consistently wrap YAML failures as `ParseError` and extract line/column metadata when available
- make fixture, workflow, benchmark-data, and golangci configuration changes trigger their relevant CI jobs
- measure aggregate core and CLI coverage with a restored 99% quality gate
- add behavior-focused coverage for prompt edge cases, parser locations, config application, color failures, regex validation, and `--neat-explain`

## Why

The project review identified a prompt-limit bypass, a public parser error type whose location fields were not populated, CI path filters that could skip relevant checks, and a coverage gate that excluded the CLI package while presenting itself as total coverage.

## How

Prompt construction now performs a bounded rebuild only when the full prompt exceeds the limit, reserving space for an accurate truncation marker without cutting records. Parser errors use a consistent wrapper with structured location extraction. CI filters and coverage commands now include the files and packages they represent. Focused tests raise CLI coverage while verifying real user-visible behavior, allowing the aggregate gate to remain at 99%.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `make security` — no vulnerabilities and zero lint issues
- `make docs-check`
- `make check-coverage` — 99.6% aggregate coverage against a 99.0% floor
- core coverage: effectively 100%; CLI coverage: 98.6%
- `gofumpt` formatting audit
- workflow YAML parsing and `zizmor` — no findings

## Notes

No new dependencies are introduced.