### PR TITLE
chore: bump Go from 1.26.5 to 1.26.7

### DIFF
--- a/.github/workflows/_docs-build.yml
+++ b/.github/workflows/_docs-build.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - name: Install Hugo extended
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - name: Run benchmarks
         run: go test -bench=. -benchmem -count=1 -benchtime=100ms -timeout=5m ./pkg/diffyml/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache: false
 
       - name: Run tests
@@ -77,7 +77,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache: false
 
       - name: Install cosign

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -89,6 +89,6 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - name: Run tests
         run: go test -race ./...
@@ -88,7 +88,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - name: Run tests
         run: go test ./... # no -race: requires a C toolchain on Windows; logic-level race coverage runs on the ubuntu test job
@@ -118,7 +118,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - name: Run fuzz tests
         run: |
@@ -138,7 +138,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
 
       - name: Run tests with coverage
         run: go test ./pkg/diffyml/... -coverprofile=coverage.out
@@ -199,7 +199,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.7"
           cache: false
 
       - name: Install goreleaser

--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ Contributions welcome! [Open an issue](https://github.com/szhekpisov/diffyml/iss
 <details>
 <summary>Development setup</summary>
 
-**Prerequisites:** Go 1.26.5+, [pre-commit](https://pre-commit.com/)
+**Prerequisites:** Go 1.26.7+, [pre-commit](https://pre-commit.com/)
 
 ```bash
 git clone https://github.com/szhekpisov/diffyml.git

--- a/docs/content/docs/install.md
+++ b/docs/content/docs/install.md
@@ -146,7 +146,7 @@ cd diffyml
 go build -o diffyml
 ```
 
-Requires Go 1.26.5 or later.
+Requires Go 1.26.7 or later.
 
 ## Verifying releases
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/szhekpisov/diffyml
 
-go 1.26.5
+go 1.26.7
 
 require go.yaml.in/yaml/v3 v3.0.5


### PR DESCRIPTION
## Why

The [v1.8.1 release run](https://github.com/szhekpisov/diffyml/actions/runs/33339727559) failed at **Scan amd64 image with Grype**:

```
ERROR discovered vulnerabilities at or above the severity threshold
##[error]Failed minimum severity level. Found vulnerabilities with level 'high' or higher
```

Nothing in our code changed — Grype pulled a vuln DB built that morning, and the binary was compiled with Go 1.26.5, which now carries 8 known stdlib advisories. Six are `high`, so the `severity-cutoff: high` gate in `release.yml` failed the job and blocked the GHCR push, the manifest/cosign/attest steps, and the `provenance`, `publish`, and `update-changelog` jobs.

## What

Bumps the Go pin 1.26.5 → **1.26.7**. All 8 advisories are fixed in 1.26.6; 1.26.7 is the latest 1.26 patch and OSV reports zero outstanding stdlib advisories for it.

| Severity | ID | Issue |
|---|---|---|
| high | GO-2026-6088 / CVE-2026-56859 | `encoding/xml` recursion depth |
| high | GO-2026-6089 / CVE-2026-56853 | `net/http` ReadHeaderTimeout on h2c check |
| high | GO-2026-6090 / CVE-2026-56862 | `crypto/tls` post-handshake message flood |
| high | GO-2026-5972 / CVE-2026-33818 | `encoding/asn1` recursion depth |
| high | GO-2026-5942 / CVE-2026-46600 | `x/net/dns/dnsmessage` panic |
| high | GO-2026-5026 / CVE-2026-39821 | `x/net/idna` Punycode |
| medium | GO-2026-6091 / CVE-2026-56858 | `html/template` regexp context |
| medium | GO-2026-6218 / CVE-2026-56860 | `net/url` resolvePath quadratic |

14 occurrences across 8 files:

- `go.mod` — the `go` directive
- `release.yml` (×2), `test.yml` (×5), `security.yml` (×2), `benchmark.yml`, `_docs-build.yml` — `setup-go` pins. These have to move alongside `go.mod`: CI sets `GOTOOLCHAIN: local`, so the newer toolchain won't be fetched on its own.
- `README.md`, `docs/content/docs/install.md` — stated prerequisite

## Testing

`go build ./...` clean and `go test ./...` passing locally on 1.26.7 (unit, cli, e2e, property).

## Follow-ups

- The **v1.8.1 GitHub release is still a draft** — GoReleaser created it with all 39 assets, but the `publish` job that undrafts it never ran. The release workflow needs a re-run once this merges.
- Unrelated warning from the same log, worth queuing separately: `7 packages from EOL distro "debian 12"` — the `distroless/static-debian12` base is past EOL and Grype notes its data may be incomplete.